### PR TITLE
add elapsed time for test command

### DIFF
--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -135,6 +135,7 @@ class CommandManager:
                 path=message.path or "Unknown",
                 timestamp=time_str,
                 snr=message.snr or "Unknown",
+                elapsed=message.elapsed or "Unknown",
                 rssi=message.rssi or "Unknown"
             )
         except (KeyError, ValueError):

--- a/modules/commands/base_command.py
+++ b/modules/commands/base_command.py
@@ -377,6 +377,29 @@ class BaseCommand(ABC):
         except:
             return "Unknown"
     
+    def format_elapsed(self, message: MeshMessage) -> str:
+        """Format message timestamp for display"""
+        if message.timestamp and message.timestamp != 'unknown':
+            try:
+                from datetime import datetime,UTC
+                el = round((datetime.now(UTC).timestamp()-message.timestamp)*1000)
+                return f"{el}ms"
+            except:
+                return str(message.timestamp)
+        else:
+            return "Unknown"
+    def format_elapsed(self, message: MeshMessage) -> str:
+        """Format message timestamp for display"""
+        if message.timestamp and message.timestamp != 'unknown':
+            try:
+                from datetime import datetime,UTC
+                el = round((datetime.now(UTC).timestamp()-message.timestamp)*1000)
+                return f"{el}ms"
+            except:
+                return str(message.timestamp)
+        else:
+            return "Unknown"
+
     def format_response(self, message: MeshMessage, response_format: str) -> str:
         """Format a response string with message data"""
         try:

--- a/modules/commands/test_command.py
+++ b/modules/commands/test_command.py
@@ -554,6 +554,7 @@ class TestCommand(BaseCommand):
         try:
             connection_info = self.build_enhanced_connection_info(message)
             timestamp = self.format_timestamp(message)
+            elapsed = self.format_elapsed(message)
             
             # Calculate distance placeholders
             path_distance = self._calculate_path_distance(message)
@@ -569,6 +570,7 @@ class TestCommand(BaseCommand):
                 connection_info=connection_info,
                 path=message.path or self.translate('common.unknown_path'),
                 timestamp=timestamp,
+                elapsed=elapsed,
                 snr=message.snr or self.translate('common.unknown'),
                 path_distance=path_distance or "",
                 firstlast_distance=firstlast_distance or ""

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -277,6 +277,17 @@ class MessageHandler:
             # but still strip control characters for security
             message_content = payload.get('text', '')
             message_content = sanitize_input(message_content, max_length=None, strip_controls=True)
+
+            # Format timestamp
+            if timestamp and timestamp != 'unknown':
+                try:
+                    from datetime import datetime,UTC
+                    dt = datetime.fromtimestamp(message.timestamp)
+                    elapsed_str = round((datetime.now(UTC).timestamp()-message.timestamp)*1000)
+                except:
+                    elapsed_str = "Unknown"
+                else:
+                    elapsed_str = "Unknown"
             
             # Convert to our message format
             message = MeshMessage(
@@ -287,6 +298,7 @@ class MessageHandler:
                 timestamp=timestamp,
                 snr=snr,
                 rssi=rssi,
+                elapsed=elapsed_str,
                 hops=path_len if path_len != 255 else 0,
                 path=path_info
             )

--- a/modules/models.py
+++ b/modules/models.py
@@ -21,3 +21,4 @@ class MeshMessage:
     timestamp: Optional[int] = None
     snr: Optional[float] = None
     rssi: Optional[int] = None
+    elapsed: Optional[str] = None


### PR DESCRIPTION
Not perfect, since the elapsed time calculation includes latency in fetching the message from the companion, but it's the best we can do for now.

Here is the config.ini entry as I use it:

test = "ack @[{sender}] {phrase_part} | {path} | {elapsed}"

