### PR TITLE
Adds `max_response_hops`

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -161,6 +161,12 @@ respond_to_dms = true
 # Example: channel_keywords = help,ping,test,hello
 # channel_keywords =
 
+# Maximum number of hops on an incoming message, any higher and it will be ignored.
+# Messages received with a high number of hops are rarely intended for the local
+# mesh and are not likely to get recieve a response.
+# Default: 64 - to not change behavior on existing installations
+max_response_hops = 10
+
 # Set a custom prefix length for the public keys to identify repeaters
 # 1 = 2 hex chars (e.g. 7E), 2 = 4 hex chars (e.g. 7E42). Also used as the mesh
 # graph key length; if the mesh often uses 2-byte paths, set to 2 to avoid

--- a/config.ini.minimal-example
+++ b/config.ini.minimal-example
@@ -207,6 +207,11 @@ monitor_channels = general,test,emergency
 # false: Bot will ignore direct messages
 respond_to_dms = true
 
+# Maximum hops for a message to get a response
+# Default: 64 - for backwards compatibility
+# Suggested: 10
+max_response_hops = 10
+
 # Optional: limit channel responses to certain keywords (e.g. help,ping,test).
 # When set, only these triggers work in channels; DMs get all triggers.
 # channel_keywords =

--- a/config.ini.quickstart
+++ b/config.ini.quickstart
@@ -18,6 +18,7 @@ db_path = meshcore_bot.db
 [Channels]
 monitor_channels = general,test,emergency
 respond_to_dms = true
+max_response_hops = 10
 
 [Banned_Users]
 banned_users = 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ The main sections include:
 - **`monitor_channels`** – Comma-separated channel names. The bot only responds to messages on these channels (and in DMs if enabled).
 - **`respond_to_dms`** – If `true`, the bot responds to direct messages; if `false`, it ignores DMs.
 - **`channel_keywords`** – Optional. When set (comma-separated command/keyword names), only those triggers are answered **in channels**; DMs always get all triggers. Use this to reduce channel traffic by making heavy triggers (e.g. `wx`, `satpass`, `joke`) DM-only. Leave empty or omit to allow all triggers in monitored channels. Per-command **`channels = `** (empty) in a command’s section also forces that command to be DM-only; see `config.ini.example` for examples (e.g. `[Joke_Command]`).
+- **`max_response_hops`** - Default: 64. The bot will ignore messages that have traveled more than this number of hops. Suggested to set at 10 or below, since in most meshes that is not an intentional message meant to trigger this particular bot.
 
 ## Command and feature sections
 

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -2790,7 +2790,21 @@ class MessageHandler:
         if not message.is_dm and not getattr(self.bot, "channel_responses_enabled", True):
             self.logger.debug("Ignoring non-DM message: channel responses paused")
             return False
-        
+
+        # Don't reply to messages from so far away the sender wont see response
+        max_response_hops = max(1, self.bot.config.getint('Channels', 'max_response_hops', fallback=64))
+        if message.hops is not None:
+            try:
+                if int(message.hops) > max_response_hops:
+                    self.logger.debug(
+                        f"Ignoring message from {message.sender_id}: "
+                        f"{message.hops} hops > max_response_hops ({max_response_hops})"
+                    )
+                    return False
+            except (TypeError, ValueError):
+                pass
+
+
         # Check if channel is monitored (with command override support)
         if not message.is_dm and message.channel:
             # Check if channel is in global monitor_channels


### PR DESCRIPTION
Before this there was no way to prevent the bot to reply to random channel noise from a temprorary strong link to another distant mesh.

This provides the ability for users in larger meshes to cap the bot to reply to only messages sent likely from nearby repeaters. This works well in conjunction with region scoping.

Default value is still 64, to not change behavior on existing installs, but the example config.ini's all include a suggested start valu of 10.