### PR TITLE
feat: !status command, !plugins command, --show-config flags, and /admin/config web viewer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,35 @@ Or if installed as a package entry point:
 .venv/bin/meshcore-bot
 ```
 
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--config <path>` | Path to the config file (default: `config.ini`) |
+| `--validate-config` | Validate config section names and paths, then exit (exit 1 on errors). See [Config validation](docs/config-validation.md). |
+| `--show-config` | Print every resolved section and key/value from the config file in INI format, then exit. |
+| `--show-config-json` | Same as `--show-config` but outputs JSON. Pipe to `jq` for filtering or use to diff configs. |
+
+Examples:
+
+```bash
+# Use a non-default config file
+.venv/bin/python meshcore_bot.py --config /etc/meshcore/prod.ini
+
+# Check the config before starting
+.venv/bin/python meshcore_bot.py --validate-config
+
+# Inspect the full resolved config
+.venv/bin/python meshcore_bot.py --show-config | less
+.venv/bin/python meshcore_bot.py --show-config > resolved.ini
+
+# JSON output — filter with jq or diff two configs
+.venv/bin/python meshcore_bot.py --show-config-json | jq '.Bot.bot_name'
+.venv/bin/python meshcore_bot.py --show-config-json > before.json
+```
+
+When the web viewer is running, the same resolved config is also available at `/admin/config` with sensitive fields redacted and a live filter box.
+
 ### Available Commands
 
 For a comprehensive list of all available commands with examples and detailed explanations, see [Command reference](docs/command-reference.md).

--- a/backup_database.py
+++ b/backup_database.py
@@ -16,11 +16,11 @@ from pathlib import Path
 def backup_database(db_path, backup_dir="backups"):
     """
     Create a timestamped backup of a SQLite database
-    
+
     Args:
         db_path: Path to the database file
         backup_dir: Directory to store backups (default: backups)
-    
+
     Returns:
         Path to the backup file if successful, None otherwise
     """
@@ -71,10 +71,10 @@ def backup_database(db_path, backup_dir="backups"):
 def check_database_status(db_path):
     """
     Check if a database file is actually used (has tables)
-    
+
     Args:
         db_path: Path to the database file
-    
+
     Returns:
         Tuple of (is_used, table_count, file_size_mb)
     """
@@ -106,11 +106,11 @@ def check_database_status(db_path):
 def find_database_files(root_dir=".", check_usage=True):
     """
     Find all SQLite database files in the root directory
-    
+
     Args:
         root_dir: Root directory to search (default: current directory)
         check_usage: If True, check which databases are actually used
-    
+
     Returns:
         List of database file paths, optionally sorted by priority (main database first)
     """

--- a/docs/config-validation.md
+++ b/docs/config-validation.md
@@ -1,8 +1,32 @@
-# Config validation
+# Config validation and inspection
 
-The bot can validate your `config.ini` for section names and path writability before you run it. Use this to catch typos (e.g. `[WebViewer]` instead of `[Web_Viewer]`) and missing required sections.
+The bot provides two pre-startup flags for verifying your `config.ini` without actually starting the bot.
 
-## How to run
+## `--show-config` / `--show-config-json` — inspect resolved values
+
+Prints every section and key/value that the bot will read, then exits. Use this to confirm the right file is being loaded and to see what defaults are active.
+
+```bash
+# Human-readable INI format
+python meshcore_bot.py --show-config [--config config.ini]
+python meshcore_bot.py --show-config | less
+python meshcore_bot.py --show-config > resolved.ini
+
+# Machine-readable JSON — pipe to jq for filtering/diffing
+python meshcore_bot.py --show-config-json
+python meshcore_bot.py --show-config-json | jq '.Bot.bot_name'
+python meshcore_bot.py --show-config-json > before.json && \
+    # edit config.ini, then:
+    python meshcore_bot.py --show-config-json > after.json && diff before.json after.json
+```
+
+## Web viewer — `/admin/config`
+
+When the web viewer is running, navigate to `/admin/config` to inspect the same resolved values in the browser. Sensitive fields (passwords, API keys, tokens) are automatically redacted. A filter box lets you search keys across all sections without scrolling.
+
+## `--validate-config` — check for errors
+
+Validates your `config.ini` for section names and path writability before you run it. Use this to catch typos (e.g. `[WebViewer]` instead of `[Web_Viewer]`) and missing required sections.
 
 **Standalone script** (no bot startup):
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,11 +33,20 @@ Get meshcore-bot running on your machine in a few minutes.
 
    Edit `config.ini`: set at least `[Connection]` (serial/BLE/TCP) and `[Bot]` (e.g. `bot_name`).
 
-3. **Run**
+3. **Verify your config** (optional but recommended)
+
+   ```bash
+   python3 meshcore_bot.py --validate-config
+   python3 meshcore_bot.py --show-config   # inspect all resolved values
+   ```
+
+4. **Run**
 
    ```bash
    python3 meshcore_bot.py
    ```
+
+   Use `--config <path>` to specify a non-default config file.
 
 ## Production deployment
 

--- a/meshcore_bot.py
+++ b/meshcore_bot.py
@@ -55,18 +55,28 @@ def main():
         action="store_true",
         help="Print the effective configuration (all sections and values) and exit",
     )
+    parser.add_argument(
+        "--show-config-json",
+        action="store_true",
+        help="Print the effective configuration as JSON and exit (pipe to jq for filtering)",
+    )
 
     args = parser.parse_args()
 
-    if args.show_config:
+    if args.show_config or args.show_config_json:
         import configparser
+        import json as _json
         cfg = configparser.ConfigParser()
         cfg.read(args.config)
-        print(f"# Effective config from: {args.config}")
-        for section in cfg.sections():
-            print(f"\n[{section}]")
-            for key, value in cfg.items(section):
-                print(f"{key} = {value}")
+        if args.show_config_json:
+            data = {section: dict(cfg.items(section)) for section in cfg.sections()}
+            print(_json.dumps(data, indent=2))
+        else:
+            print(f"# Effective config from: {args.config}")
+            for section in cfg.sections():
+                print(f"\n[{section}]")
+                for key, value in cfg.items(section):
+                    print(f"{key} = {value}")
         sys.exit(0)
 
     if args.validate_config:

--- a/meshcore_bot.py
+++ b/meshcore_bot.py
@@ -50,8 +50,24 @@ def main():
         action="store_true",
         help="Validate config section names and exit before starting the bot (exit 1 on errors)",
     )
+    parser.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Print the effective configuration (all sections and values) and exit",
+    )
 
     args = parser.parse_args()
+
+    if args.show_config:
+        import configparser
+        cfg = configparser.ConfigParser()
+        cfg.read(args.config)
+        print(f"# Effective config from: {args.config}")
+        for section in cfg.sections():
+            print(f"\n[{section}]")
+            for key, value in cfg.items(section):
+                print(f"{key} = {value}")
+        sys.exit(0)
 
     if args.validate_config:
         from modules.config_validation import (

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -15,7 +15,7 @@ from meshcore import EventType
 
 from .commands.base_command import BaseCommand
 from .config_validation import (
-    PUBLIC_CHANNEL_KEY_HEX,
+    PUBLIC_CHANNEL_KEY_HEX,  # noqa: F401 — re-exported; used by core.py
     PUBLIC_CHANNEL_OVERRIDE_KEY,
     _channel_name_is_public,
     strip_optional_quotes,

--- a/modules/commands/plugins_command.py
+++ b/modules/commands/plugins_command.py
@@ -13,22 +13,27 @@ from .base_command import BaseCommand
 class PluginsCommand(BaseCommand):
     """Lists loaded service plugins with their descriptions."""
 
+    # Plugin metadata
     name = "plugins"
     keywords = ["plugins"]
     description = "List active service plugins and their descriptions."
     category = "admin"
 
+    # Documentation
     short_description = "List loaded service plugins"
     usage = "plugins"
     examples = ["plugins"]
 
     def __init__(self, bot: Any) -> None:
         super().__init__(bot)
-        self.enabled = self.get_config_value("Plugins_Command", "enabled", fallback=True, value_type="bool")
+        self.plugins_enabled = self.get_config_value("Plugins_Command", "enabled", fallback=True, value_type="bool")
+
+    def can_execute(self, message: MeshMessage, skip_channel_check: bool = False) -> bool:
+        if not self.plugins_enabled:
+            return False
+        return super().can_execute(message, skip_channel_check=skip_channel_check)
 
     async def execute(self, message: MeshMessage) -> bool:
-        if not self.enabled:
-            return False
         try:
             response = self._build_list()
             return await self.send_response(message, response)

--- a/modules/commands/plugins_command.py
+++ b/modules/commands/plugins_command.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Plugins command for the MeshCore Bot
+Lists all active service plugins and their descriptions
+"""
+
+from typing import Any
+
+from ..models import MeshMessage
+from .base_command import BaseCommand
+
+
+class PluginsCommand(BaseCommand):
+    """Lists loaded service plugins with their descriptions."""
+
+    name = "plugins"
+    keywords = ["plugins"]
+    description = "List active service plugins and their descriptions."
+    category = "admin"
+
+    short_description = "List loaded service plugins"
+    usage = "plugins"
+    examples = ["plugins"]
+
+    def __init__(self, bot: Any) -> None:
+        super().__init__(bot)
+        self.enabled = self.get_config_value("Plugins_Command", "enabled", fallback=True, value_type="bool")
+
+    async def execute(self, message: MeshMessage) -> bool:
+        if not self.enabled:
+            return False
+        try:
+            response = self._build_list()
+            return await self.send_response(message, response)
+        except Exception as e:
+            self.logger.error("Error in plugins command: %s", e)
+            return False
+
+    def _build_list(self) -> str:
+        try:
+            services = self.bot.services or {}
+        except Exception:
+            services = {}
+
+        if not services:
+            return "No service plugins loaded."
+
+        lines = [f"Plugins ({len(services)}):"]
+        for name, plugin in sorted(services.items()):
+            desc = getattr(plugin, "description", "") or ""
+            if desc:
+                desc = desc[:60] + ("..." if len(desc) > 60 else "")
+                lines.append(f"  {name}: {desc}")
+            else:
+                lines.append(f"  {name}")
+
+        return "\n".join(lines)

--- a/modules/commands/status_command.py
+++ b/modules/commands/status_command.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Status command for the MeshCore Bot
+Admin DM-only command showing live bot health snapshot
+"""
+
+import os
+import time
+from typing import Any
+
+from ..models import MeshMessage
+from .base_command import BaseCommand
+
+
+class StatusCommand(BaseCommand):
+    """Admin DM command returning a live health snapshot of the bot."""
+
+    name = "status"
+    keywords = ["status"]
+    description = "Show live bot status: uptime, radio state, DB size, loaded services."
+    requires_dm = True
+    category = "admin"
+
+    short_description = "Show live bot health snapshot (admin DM only)"
+    usage = "status"
+    examples = ["status"]
+
+    def __init__(self, bot: Any) -> None:
+        super().__init__(bot)
+        self.enabled = self.get_config_value("Status_Command", "enabled", fallback=True, value_type="bool")
+
+    async def execute(self, message: MeshMessage) -> bool:
+        if not self.enabled:
+            return False
+        try:
+            response = self._build_status()
+            return await self.send_response(message, response)
+        except Exception as e:
+            self.logger.error("Error in status command: %s", e)
+            return False
+
+    def _build_status(self) -> str:
+        lines = []
+
+        # Uptime
+        start = getattr(self.bot, "start_time", None)
+        if start:
+            elapsed = int(time.time() - start)
+            d, rem = divmod(elapsed, 86400)
+            h, rem = divmod(rem, 3600)
+            m = rem // 60
+            if d:
+                uptime = f"{d}d {h}h {m}m"
+            elif h:
+                uptime = f"{h}h {m}m"
+            else:
+                uptime = f"{m}m"
+        else:
+            uptime = "unknown"
+        lines.append(f"Up: {uptime}")
+
+        # Radio state
+        zombie = getattr(self.bot, "is_radio_zombie", False)
+        if callable(zombie):
+            zombie = zombie()
+        offline = getattr(self.bot, "is_radio_offline", False)
+        if callable(offline):
+            offline = offline()
+        if zombie:
+            lines.append("Radio: ZOMBIE")
+        elif offline:
+            lines.append("Radio: OFFLINE")
+        else:
+            lines.append("Radio: ok")
+
+        # DB size
+        try:
+            db_path = str(self.bot.db_manager.db_path)
+            size = os.path.getsize(db_path)
+            if size >= 1_048_576:
+                db_str = f"{size / 1_048_576:.1f} MB"
+            elif size >= 1024:
+                db_str = f"{size / 1024:.0f} KB"
+            else:
+                db_str = f"{size} B"
+        except Exception:
+            db_str = "unknown"
+        lines.append(f"DB: {db_str}")
+
+        # Channels
+        try:
+            channels = self.bot.command_manager.monitor_channels or []
+            lines.append(f"Channels: {len(channels)}")
+        except Exception:
+            pass
+
+        # Loaded services
+        try:
+            services = self.bot.services or {}
+            if services:
+                lines.append(f"Services: {len(services)} ({', '.join(services.keys())})")
+            else:
+                lines.append("Services: none")
+        except Exception:
+            pass
+
+        return "\n".join(lines)

--- a/modules/commands/status_command.py
+++ b/modules/commands/status_command.py
@@ -15,23 +15,28 @@ from .base_command import BaseCommand
 class StatusCommand(BaseCommand):
     """Admin DM command returning a live health snapshot of the bot."""
 
+    # Plugin metadata
     name = "status"
     keywords = ["status"]
     description = "Show live bot status: uptime, radio state, DB size, loaded services."
     requires_dm = True
     category = "admin"
 
+    # Documentation
     short_description = "Show live bot health snapshot (admin DM only)"
     usage = "status"
     examples = ["status"]
 
     def __init__(self, bot: Any) -> None:
         super().__init__(bot)
-        self.enabled = self.get_config_value("Status_Command", "enabled", fallback=True, value_type="bool")
+        self.status_enabled = self.get_config_value("Status_Command", "enabled", fallback=True, value_type="bool")
+
+    def can_execute(self, message: MeshMessage, skip_channel_check: bool = False) -> bool:
+        if not self.status_enabled:
+            return False
+        return super().can_execute(message, skip_channel_check=skip_channel_check)
 
     async def execute(self, message: MeshMessage) -> bool:
-        if not self.enabled:
-            return False
         try:
             response = self._build_status()
             return await self.send_response(message, response)

--- a/modules/core.py
+++ b/modules/core.py
@@ -1035,7 +1035,7 @@ long_jokes = false
         # Register signal handlers
         signal.signal(signal.SIGTERM, signal_handler)
         signal.signal(signal.SIGINT, signal_handler)
-    
+
     async def _attempt_reconnect(self) -> bool:
         """Attempt to reconnect to the MeshCore node with exponential backoff.
 

--- a/modules/security_utils.py
+++ b/modules/security_utils.py
@@ -42,7 +42,7 @@ def _is_nix_environment() -> bool:
     return bool(any(var in os.environ for var in nix_env_vars))
 
 
-def validate_external_url(url: str, allow_localhost: bool = False, timeout: float = 2.0) -> bool:
+def validate_external_url(url: str, allow_localhost: bool = False, allow_private: bool = False, timeout: float = 2.0) -> bool:
     """
     Validate that URL points to safe external resource (SSRF protection)
 
@@ -84,8 +84,8 @@ def validate_external_url(url: str, allow_localhost: bool = False, timeout: floa
 
             ip_obj = ipaddress.ip_address(ip)
 
-            # If localhost is not allowed, reject private/internal IPs
-            if not allow_localhost:
+            # If localhost/private IPs are not allowed, reject them
+            if not (allow_localhost or allow_private):
                 # Reject private/internal IPs
                 if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
                     logger.warning(f"URL resolves to private/internal IP: {ip}")

--- a/modules/security_utils.py
+++ b/modules/security_utils.py
@@ -16,6 +16,9 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger('MeshCoreBot.Security')
 
+# CGN (Carrier-Grade NAT) network 100.64.0.0/10 - RFC 6598
+_CGN_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
 
 def _is_nix_environment() -> bool:
     """
@@ -84,11 +87,16 @@ def validate_external_url(url: str, allow_localhost: bool = False, allow_private
 
             ip_obj = ipaddress.ip_address(ip)
 
-            # If localhost/private IPs are not allowed, reject them
+            # If localhost/private is not allowed, reject private/internal IPs
             if not (allow_localhost or allow_private):
                 # Reject private/internal IPs
                 if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
                     logger.warning(f"URL resolves to private/internal IP: {ip}")
+                    return False
+
+                # Reject CGN (Carrier-Grade NAT) - RFC 6598
+                if ip_obj in _CGN_NETWORK:
+                    logger.warning(f"URL resolves to CGN IP: {ip}")
                     return False
 
                 # Reject reserved ranges

--- a/modules/service_plugins/packet_capture_service.py
+++ b/modules/service_plugins/packet_capture_service.py
@@ -19,10 +19,10 @@ from meshcore import EventType
 
 # Import bot's enums
 from ..enums import PayloadType, PayloadVersion, RouteType
-from ..version_info import resolve_runtime_version
 
 # Import bot's utilities for packet hash
 from ..utils import calculate_packet_hash, decode_path_len_byte, parse_trace_payload_route_hashes
+from ..version_info import resolve_runtime_version
 
 # Import MQTT client
 try:

--- a/modules/version_info.py
+++ b/modules/version_info.py
@@ -13,10 +13,9 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Optional
 
 
-def _normalize_tag(value: Optional[str]) -> Optional[str]:
+def _normalize_tag(value: str | None) -> str | None:
     if not value:
         return None
     value = value.strip()
@@ -25,7 +24,7 @@ def _normalize_tag(value: Optional[str]) -> Optional[str]:
     return value if value.startswith("v") else f"v{value}"
 
 
-def _safe_git_run(repo_root: Path, args: list[str]) -> Optional[str]:
+def _safe_git_run(repo_root: Path, args: list[str]) -> str | None:
     try:
         result = subprocess.run(
             ["git", "-C", str(repo_root)] + args,
@@ -41,7 +40,7 @@ def _safe_git_run(repo_root: Path, args: list[str]) -> Optional[str]:
         return None
 
 
-def _read_version_file(repo_root: Path) -> Optional[str]:
+def _read_version_file(repo_root: Path) -> str | None:
     version_file = repo_root / ".version_info"
     if not version_file.is_file():
         return None
@@ -54,7 +53,7 @@ def _read_version_file(repo_root: Path) -> Optional[str]:
         return None
 
 
-def _read_pyproject_version(repo_root: Path) -> Optional[str]:
+def _read_pyproject_version(repo_root: Path) -> str | None:
     pyproject_path = repo_root / "pyproject.toml"
     if not pyproject_path.is_file():
         return None
@@ -79,7 +78,7 @@ def _read_pyproject_version(repo_root: Path) -> Optional[str]:
     return None
 
 
-def resolve_runtime_version(repo_root: Path | str) -> dict[str, Optional[str]]:
+def resolve_runtime_version(repo_root: Path | str) -> dict[str, str | None]:
     """Resolve version metadata and a single runtime display value.
 
     Returns a dict with:
@@ -103,7 +102,7 @@ def resolve_runtime_version(repo_root: Path | str) -> dict[str, Optional[str]]:
         # %ci format is "YYYY-MM-DD HH:MM:SS +TZ"; keep date only.
         date = date_raw.split()[0] if " " in date_raw else date_raw
 
-    display: Optional[str]
+    display: str | None
     if branch and branch != "main" and commit:
         display = f"{branch}-{commit}"
     elif branch == "main" and baked:

--- a/modules/web_viewer/app.py
+++ b/modules/web_viewer/app.py
@@ -10,13 +10,15 @@ import logging
 import os
 import re
 import sqlite3
+import subprocess
 import sys
 import threading
 import time
 from contextlib import closing, contextmanager, suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
+from urllib.parse import urlparse
 
 from flask import (
     Flask,
@@ -33,8 +35,11 @@ from flask import (
 )
 from flask_socketio import SocketIO, disconnect, emit
 
-from modules.security_utils import VALID_JOURNAL_MODES, validate_sql_identifier
-from modules.version_info import resolve_runtime_version
+from modules.security_utils import (
+    VALID_JOURNAL_MODES,
+    validate_external_url,
+    validate_sql_identifier,
+)
 
 
 def _apply_werkzeug_websocket_fix() -> None:
@@ -93,6 +98,33 @@ from modules.web_viewer.integration import normalized_web_viewer_password
 class BotDataViewer:
     """Complete web interface using Flask-SocketIO 5.x best practices"""
 
+    # Whitelist of allowed tables for security
+    ALLOWED_TABLES = {
+        'geocoding_cache',
+        'generic_cache',
+        'bot_metadata',
+        'packet_stream',
+        'message_stats',
+        'command_stats',
+        'greeted_users',
+        'repeater_contacts',
+        'complete_contact_tracking',
+        'daily_stats',
+        'unique_advert_packets',
+        'purging_log',
+        'mesh_connections',
+        'observed_paths',
+        'feed_subscriptions',
+        'feed_activity',
+        'feed_errors',
+        'feed_message_queue',
+        'channel_operations',
+        'channels',
+        'path_stats',
+        'schema_version',
+        'greeter_rollout',
+    }
+
     def __init__(self, db_path="meshcore_bot.db", repeater_db_path=None, config_path="config.ini"):
         # Setup comprehensive logging
         self._setup_logging()
@@ -143,6 +175,7 @@ class BotDataViewer:
 
         # Load configuration
         self.config = self._load_config(config_path)
+        self.config_path = config_path  # kept for config.ini write-back endpoints
 
         # Resolve db_path relative to the config file's directory — matches core.py's bot_root
         # property which is Path(config_file).parent.resolve().  Using self.bot_root (the project
@@ -248,15 +281,56 @@ class BotDataViewer:
             config.read(config_path)
         return config
 
-    def _get_version_info(self) -> dict[str, Optional[str]]:
-        """Get version info for footer from shared runtime resolver."""
-        info = resolve_runtime_version(self.bot_root)
-        return {
-            "tag": info.get("tag"),
-            "branch": info.get("branch"),
-            "commit": info.get("commit"),
-            "date": info.get("date"),
-        }
+    def _get_version_info(self) -> dict[str, str | None]:
+        """Get version info for footer: tag if on a tag, else branch, commit hash and date.
+        Checks MESHCORE_BOT_VERSION env (Docker/build), then .version_info, then git. Never raises."""
+        out: dict[str, str | None] = {"tag": None, "branch": None, "commit": None, "date": None}
+        # Docker / CI: version set at build time (e.g. ARG + ENV in Dockerfile)
+        env_version = os.environ.get("MESHCORE_BOT_VERSION", "").strip()
+        if env_version:
+            out["tag"] = env_version if env_version.startswith("v") else f"v{env_version}"
+            return out
+        version_file = self.bot_root / ".version_info"
+        try:
+            if version_file.is_file():
+                with open(version_file) as f:
+                    data = json.load(f)
+                # Installer/tag installs write installer_version (often the tag name)
+                tag = data.get("installer_version") or data.get("tag")
+                if tag:
+                    out["tag"] = tag if tag.startswith("v") else f"v{tag}"
+                    return out
+        except (OSError, json.JSONDecodeError, KeyError):
+            pass
+        try:
+            def run(cmd: list[str]) -> str | None:
+                args = ["git", "-C", str(self.bot_root)] + cmd
+                result = subprocess.run(
+                    args, capture_output=True, text=True, timeout=5
+                )
+                if result.returncode != 0:
+                    return None
+                return (result.stdout or "").strip() or None
+
+            # Check if HEAD is a tag
+            tag = run(["describe", "--exact-match", "HEAD"])
+            if tag:
+                out["tag"] = tag if tag.startswith("v") else f"v{tag}"
+                return out
+            branch = run(["rev-parse", "--abbrev-ref", "HEAD"])
+            commit = run(["rev-parse", "--short", "HEAD"])
+            date_raw = run(["show", "-s", "--format=%ci", "HEAD"])
+            out["branch"] = branch or None
+            out["commit"] = commit or None
+            if date_raw:
+                try:
+                    # %ci is "YYYY-MM-DD HH:MM:SS +tz"; take date part only
+                    out["date"] = date_raw.split()[0]
+                except IndexError:
+                    out["date"] = date_raw
+            return out
+        except (subprocess.TimeoutExpired, subprocess.CalledProcessError, FileNotFoundError, OSError):
+            return out
 
     def _setup_template_context(self):
         """Setup template context processor to inject global variables"""
@@ -278,15 +352,42 @@ class BotDataViewer:
                     bot_name = (self.config.get('Bot', 'bot_name', fallback='MeshCore Bot') or '').strip() or 'MeshCore Bot'
                 except (configparser.NoSectionError, configparser.NoOptionError):
                     bot_name = 'MeshCore Bot'
+                try:
+                    radio_zombie = self.db_manager.get_metadata('bot.radio_zombie') == 'true'
+                    radio_zombie_since = self.db_manager.get_metadata('bot.radio_zombie_since') or None
+                    radio_offline = self.db_manager.get_metadata('bot.radio_offline') == 'true'
+                    radio_offline_since = self.db_manager.get_metadata('bot.radio_offline_since') or None
+                    bot_initializing = self.db_manager.get_metadata('bot.initializing') == 'true'
+                except Exception:
+                    radio_zombie = False
+                    radio_zombie_since = None
+                    radio_offline = False
+                    radio_offline_since = None
+                    bot_initializing = False
                 return {
                     'greeter_enabled': greeter_enabled,
                     'feed_manager_enabled': feed_manager_enabled,
                     'bot_name': bot_name,
                     'version_info': version_info,
+                    'radio_zombie': radio_zombie,
+                    'radio_zombie_since': radio_zombie_since,
+                    'radio_offline': radio_offline,
+                    'radio_offline_since': radio_offline_since,
+                    'bot_initializing': bot_initializing,
                 }
             except Exception as e:
                 self.logger.exception("Template context processor failed: %s", e)
-                return {'greeter_enabled': False, 'feed_manager_enabled': False, 'bot_name': 'MeshCore Bot', 'version_info': version_info}
+                return {
+                    'greeter_enabled': False,
+                    'feed_manager_enabled': False,
+                    'bot_name': 'MeshCore Bot',
+                    'bot_initializing': False,
+                    'version_info': version_info,
+                    'radio_zombie': False,
+                    'radio_zombie_since': None,
+                    'radio_offline': False,
+                    'radio_offline_since': None,
+                }
 
     def _init_databases(self):
         """Initialize database connections"""
@@ -439,7 +540,7 @@ class BotDataViewer:
                     bot_latitude = lat
                     bot_longitude = lon
                     geographic_guessing_enabled = True
-        except Exception:
+        except (ValueError, configparser.Error):  # malformed float or missing section
             pass
 
         # Path command settings
@@ -917,8 +1018,8 @@ class BotDataViewer:
                                         path_validation_bonus = min(graph_path_validation_max_bonus, path_validation_bonus)
                                         if path_validation_bonus >= graph_path_validation_max_bonus * 0.9:
                                             break  # Strong match found, no need to check more
-                    except Exception:
-                        pass
+                    except (sqlite3.Error, OSError, KeyError, ValueError) as _score_err:
+                        self.logger.debug("Path-scoring graph query failed: %s", _score_err)
 
                 # Add path validation bonus to graph score
                 candidate_score = min(1.0, candidate_score + path_validation_bonus)
@@ -1146,7 +1247,13 @@ class BotDataViewer:
         @self.app.errorhandler(500)
         def internal_error(e):
             self.logger.exception("Unhandled exception (500): %s", e)
-            return make_response(("Internal Server Error", 500))
+            if request.path.startswith('/api/') or request.accept_mimetypes.best == 'application/json':
+                return make_response(jsonify({'error': 'An internal error occurred — see server logs'}), 500)
+            return make_response(render_template('error.html',
+                error_code=500,
+                error_title='Internal Server Error',
+                error_message='Something went wrong on our end. The error has been logged.',
+            ), 500)
 
         # Authentication middleware (BUG-001)
         _EXEMPT_PATHS = frozenset([
@@ -1163,7 +1270,7 @@ class BotDataViewer:
                 return
             if session.get('authenticated'):
                 return
-            if request.path.startswith('/api/') or request.is_json:
+            if request.path.startswith('/api/'):
                 return make_response(jsonify({'error': 'Authentication required'}), 401)
             next_url = request.path
             return redirect(url_for('login', next=next_url))
@@ -1238,7 +1345,8 @@ class BotDataViewer:
                 if password == self.web_viewer_password:
                     session['authenticated'] = True
                     next_url = request.args.get('next', '/')
-                    if not next_url.startswith('/') or next_url.startswith('//'):
+                    parsed = urlparse(next_url)
+                    if parsed.scheme or parsed.netloc or not next_url.startswith('/'):
                         next_url = '/'
                     return redirect(next_url)
                 return render_template('login.html', error='Invalid password')
@@ -1313,6 +1421,7 @@ class BotDataViewer:
                 'notif.smtp_user', 'notif.smtp_password',
                 'notif.from_name', 'notif.from_email',
                 'notif.recipients', 'notif.nightly_enabled',
+                'notif.allow_local_smtp',
             ]
             settings = {}
             for k in keys:
@@ -1371,6 +1480,14 @@ class BotDataViewer:
                 return jsonify({'error': 'Sender email is not configured'}), 400
             if not recipients:
                 return jsonify({'error': 'No recipients configured'}), 400
+
+            # Validate SMTP host for SSRF protection
+            # allow_local_smtp=true permits private/internal SMTP hosts (e.g., local Postfix)
+            allow_local_smtp = _get('allow_local_smtp').lower() == 'true'
+            if not validate_external_url(f'http://{smtp_host}', allow_private=allow_local_smtp):
+                if allow_local_smtp:
+                    return jsonify({'error': 'Invalid or unsafe SMTP host'}), 400
+                return jsonify({'error': 'Invalid or unsafe SMTP host (private/internal IP blocked)'}), 400
 
             try:
                 msg = EmailMessage()
@@ -1489,6 +1606,193 @@ class BotDataViewer:
             self.logger.info(f"Maintenance config updated: {', '.join(saved)}")
             return jsonify({'success': True, 'saved': saved})
 
+        # ── Zombie radio alert config ────────────────────────────────────────
+
+        @self.app.route('/api/config/zombie-alert')
+        def api_config_zombie_alert_get() -> "Response":
+            """Return zombie alert settings.
+
+            Response includes both ``bot_metadata`` values (set via web UI) and
+            ``config_ini`` values (read from config.ini) so the browser can
+            show config.ini as the baseline defaults.
+            """
+            meta: dict[str, str] = {}
+            for key in ('zombie.alert_enabled', 'zombie.alert_email'):
+                short = key.split('.', 1)[1]
+                val = self.db_manager.get_metadata(key)
+                meta[short] = val if isinstance(val, str) else ''
+            if not meta.get('alert_enabled'):
+                meta['alert_enabled'] = 'false'
+            ini: dict[str, str] = {
+                'alert_enabled': (
+                    'true'
+                    if self.config.getboolean('Bot', 'radio_zombie_alert_enabled', fallback=False)
+                    else 'false'
+                ),
+                'alert_email': self.config.get('Bot', 'radio_zombie_alert_email', fallback=''),
+            }
+            return jsonify({'meta': meta, 'config_ini': ini})
+
+        @self.app.route('/api/config/zombie-alert', methods=['POST'])
+        def api_config_zombie_alert_post() -> "Response":
+            """Save zombie alert settings to bot_metadata.
+
+            If ``write_to_config`` is ``true`` in the request body, the values
+            are also written back to config.ini under ``[Bot]``.  The config
+            object in memory is updated immediately so the scheduler reads the
+            new values without a restart.
+            """
+            data = request.get_json(silent=True) or {}
+            allowed = {'alert_enabled', 'alert_email'}
+            saved = []
+            for field in allowed:
+                if field in data:
+                    self.db_manager.set_metadata(f'zombie.{field}', str(data[field]))
+                    saved.append(field)
+            self.logger.info("Zombie alert config updated (metadata): %s", ', '.join(saved))
+
+            write_to_config = str(data.get('write_to_config', '')).lower() == 'true'
+            config_saved = False
+            if write_to_config:
+                try:
+                    if not self.config.has_section('Bot'):
+                        self.config.add_section('Bot')
+                    if 'alert_enabled' in data:
+                        self.config.set(
+                            'Bot', 'radio_zombie_alert_enabled',
+                            'true' if str(data['alert_enabled']).lower() == 'true' else 'false',
+                        )
+                    if 'alert_email' in data:
+                        self.config.set('Bot', 'radio_zombie_alert_email', str(data['alert_email']))
+                    with open(self.config_path, 'w') as fh:
+                        self.config.write(fh)
+                    config_saved = True
+                    self.logger.info("Zombie alert settings written to config.ini")
+                except OSError as exc:
+                    self.logger.error("Failed to write zombie alert settings to config.ini: %s", exc)
+                    return jsonify({
+                        'success': False,
+                        'error': 'Could not write config.ini — check file permissions',
+                    }), 500
+
+            return jsonify({'success': True, 'saved': saved, 'config_saved': config_saved})
+
+        # ── Zombie recover ───────────────────────────────────────────────────
+
+        @self.app.route('/api/admin/zombie-recover', methods=['POST'])
+        def api_admin_zombie_recover() -> "Response":
+            """Clear zombie state so bot resumes processing after a radio power cycle.
+
+            Clears the ``_radio_zombie_detected`` flag on the live bot object (if
+            accessible) and removes the persisted flag from bot_metadata so the
+            web-viewer banner disappears on the next page load.
+            """
+            try:
+                self.db_manager.set_metadata('bot.radio_zombie', 'false')
+                self.db_manager.set_metadata('bot.radio_zombie_since', '')
+                bot = getattr(self, 'bot', None)
+                if bot is not None:
+                    bot._radio_zombie_detected = False
+                    bot._radio_fail_count = 0
+                    bot._last_radio_probe = 0  # force probe on next cycle
+                self.logger.info("Zombie state cleared via web UI recover action")
+                return jsonify({'success': True, 'message': 'Zombie state cleared; bot will resume'})
+            except Exception:
+                self.logger.exception("Error clearing zombie state")
+                return jsonify({'success': False, 'error': 'Internal error — see server logs'}), 500
+
+        # ── Radio debug config ───────────────────────────────────────────────
+
+        @self.app.route('/api/config/radio-debug')
+        def api_config_radio_debug_get() -> "Response":
+            """Return current radio debug logging setting.
+
+            Response includes both ``bot_metadata`` value (set via web UI) and
+            ``config_ini`` value (read from config.ini) so the browser can show
+            which is the persistent baseline.
+            """
+            meta_val = self.db_manager.get_metadata('radio.debug')
+            meta_enabled = meta_val if isinstance(meta_val, str) else ''
+            ini_enabled = (
+                'true'
+                if self.config.getboolean('Connection', 'radio_debug', fallback=False)
+                else 'false'
+            )
+            return jsonify({'meta': {'enabled': meta_enabled}, 'config_ini': {'enabled': ini_enabled}})
+
+        @self.app.route('/api/config/radio-debug', methods=['POST'])
+        def api_config_radio_debug_post() -> "Response":
+            """Save radio debug logging setting.
+
+            Body fields:
+            - ``enabled``: ``'true'`` or ``'false'``
+            - ``write_to_config``: ``'true'`` to also write ``[Connection]
+              radio_debug`` to config.ini
+            - ``reconnect``: ``'true'`` to queue a radio reconnect so the
+              change takes effect immediately (the debug flag is only applied
+              at connection time)
+            """
+            try:
+                data = request.get_json(silent=True) or {}
+                enabled = str(data.get('enabled', 'false')).lower() == 'true'
+                write_to_config = str(data.get('write_to_config', 'false')).lower() == 'true'
+                do_reconnect = str(data.get('reconnect', 'false')).lower() == 'true'
+
+                self.db_manager.set_metadata('radio.debug', 'true' if enabled else 'false')
+                config_saved = False
+
+                if write_to_config:
+                    try:
+                        if not self.config.has_section('Connection'):
+                            self.config.add_section('Connection')
+                        self.config.set('Connection', 'radio_debug', 'true' if enabled else 'false')
+                        with open(self.config_path, 'w') as fh:
+                            self.config.write(fh)
+                        config_saved = True
+                        self.logger.info(
+                            "radio_debug=%s written to config.ini by web UI", 'true' if enabled else 'false'
+                        )
+                    except OSError as exc:
+                        self.logger.error("Failed to write radio_debug to config.ini: %s", exc)
+                        return jsonify({
+                            'success': False,
+                            'error': 'Could not write config.ini — check file permissions',
+                        }), 500
+
+                op_id = None
+                if do_reconnect:
+                    with self.db_manager.connection() as conn:
+                        cursor = conn.cursor()
+                        cursor.execute(
+                            "INSERT INTO channel_operations (operation_type, status) VALUES ('radio_connect', 'pending')"
+                        )
+                        conn.commit()
+                        op_id = cursor.lastrowid
+                    self.logger.info("Radio reconnect queued (op_id=%s) to apply radio_debug=%s", op_id, enabled)
+
+                return jsonify({'success': True, 'config_saved': config_saved, 'op_id': op_id})
+            except Exception as exc:
+                self.logger.exception("Error saving radio debug config")
+                return jsonify({'success': False, 'error': str(exc)}), 500
+
+        # ── Radio offline clear ──────────────────────────────────────────────
+
+        @self.app.route('/api/admin/radio-offline-clear', methods=['POST'])
+        def api_admin_radio_offline_clear() -> "Response":
+            """Clear the radio-offline flag so the bot resumes outbound sends."""
+            try:
+                self.db_manager.set_metadata('bot.radio_offline', 'false')
+                self.db_manager.set_metadata('bot.radio_offline_since', '')
+                bot = getattr(self, 'bot', None)
+                if bot is not None:
+                    bot._radio_offline = False
+                    bot._send_consecutive_failures = 0
+                self.logger.info("Radio-offline state cleared via web UI action")
+                return jsonify({'success': True, 'message': 'Radio-offline flag cleared; sends will resume'})
+            except Exception:
+                self.logger.exception("Error clearing radio-offline state")
+                return jsonify({'success': False, 'error': 'Internal error — see server logs'}), 500
+
         # ── Maintenance status ───────────────────────────────────────────────
 
         @self.app.route('/api/maintenance/backup_now', methods=['POST'])
@@ -1527,12 +1831,23 @@ class BotDataViewer:
                 backup_dir_str = self.db_manager.get_metadata('maint.db_backup_dir') or ''
                 if not backup_dir_str or not os.path.isdir(backup_dir_str):
                     return jsonify({'error': 'No valid backup directory configured'}), 400
-                # Ensure the resolved path is within the backup directory (prevents traversal)
+
+                # Validate path is within the configured backup directory
+                # First check for dangerous system paths, then check if path is within backup dir
                 backup_dir = Path(backup_dir_str).resolve()
                 src = Path(db_file).resolve()
+
+                # Check for dangerous system paths first (returns 400)
+                target_str = str(src).lower()
+                dangerous_prefixes = ['/etc', '/sys', '/proc', '/dev', '/bin', '/sbin', '/boot']
+                if any(target_str.startswith(prefix) for prefix in dangerous_prefixes):
+                    return jsonify({'error': 'Access to system directory denied'}), 400
+
+                # Check if path is within the backup directory (prevents traversal)
                 try:
                     src.relative_to(backup_dir)
                 except ValueError:
+                    # Path is outside backup directory - return 403
                     return jsonify({'error': 'Restore path must be within the configured backup directory'}), 403
 
                 if not src.exists():
@@ -1629,7 +1944,7 @@ class BotDataViewer:
                 data = request.get_json(silent=True) or {}
                 raw = data.get('keep_days', 'all')
                 if raw == 'all' or raw == 'All':
-                    keep_days: Union[str, int] = 'all'
+                    keep_days: str | int = 'all'
                 else:
                     try:
                         keep_days = int(raw)
@@ -1638,7 +1953,7 @@ class BotDataViewer:
                 if keep_days not in _VALID_KEEP_DAYS:
                     return jsonify({'error': f'keep_days must be one of {sorted(v for v in _VALID_KEEP_DAYS if isinstance(v, int))} or "all"'}), 400
 
-                tables_filter: Optional[list[str]] = None
+                tables_filter: list[str] | None = None
                 if 'tables' in data:
                     tf = data.get('tables')
                     if tf is None:
@@ -1732,6 +2047,23 @@ class BotDataViewer:
                 result[short] = val if val is not None else ''
             return jsonify(result)
 
+        @self.app.route('/api-explorer')
+        def api_explorer():
+            """API Explorer — browse all endpoints with curl examples."""
+            return render_template('api_explorer.html')
+
+        @self.app.route('/admin/config')
+        def admin_config():
+            """Resolved config viewer — shows effective config.ini values with sensitive fields redacted."""
+            _REDACT_KEYS = {'password', 'smtp_password', 'api_key', 'token', 'secret', 'smtp_user'}
+            sections = {}
+            for section in self.config.sections():
+                sections[section] = {
+                    k: '●●●●●●' if any(r in k for r in _REDACT_KEYS) else v
+                    for k, v in self.config.items(section)
+                }
+            return render_template('admin_config.html', sections=sections, config_path=self.config_path)
+
         @self.app.route('/mesh')
         def mesh():
             """Mesh graph visualization page"""
@@ -1796,13 +2128,41 @@ class BotDataViewer:
             with self._clients_lock:
                 client_count = len(self.connected_clients)
 
+            radio_zombie = self.db_manager.get_metadata('bot.radio_zombie') == 'true'
+            radio_zombie_since = self.db_manager.get_metadata('bot.radio_zombie_since') or None
+
             return jsonify({
-                'status': 'healthy',
+                'status': 'degraded' if radio_zombie else 'healthy',
                 'connected_clients': client_count,
                 'max_clients': self.max_clients,
                 'timestamp': time.time(),
                 'bot_uptime': bot_uptime,
-                'version': 'modern_2.0'
+                'version': 'modern_2.0',
+                'radio_zombie': radio_zombie,
+                'radio_zombie_since': radio_zombie_since,
+            })
+
+        @self.app.route('/api/banner-status')
+        def api_banner_status():
+            """Return current banner states for live JS polling."""
+            try:
+                radio_zombie = self.db_manager.get_metadata('bot.radio_zombie') == 'true'
+                radio_zombie_since = self.db_manager.get_metadata('bot.radio_zombie_since') or None
+                radio_offline = self.db_manager.get_metadata('bot.radio_offline') == 'true'
+                radio_offline_since = self.db_manager.get_metadata('bot.radio_offline_since') or None
+                bot_initializing = self.db_manager.get_metadata('bot.initializing') == 'true'
+            except Exception:
+                radio_zombie = False
+                radio_zombie_since = None
+                radio_offline = False
+                radio_offline_since = None
+                bot_initializing = False
+            return jsonify({
+                'radio_zombie': radio_zombie,
+                'radio_zombie_since': radio_zombie_since,
+                'radio_offline': radio_offline,
+                'radio_offline_since': radio_offline_since,
+                'bot_initializing': bot_initializing,
             })
 
         @self.app.route('/api/system-health')
@@ -1828,6 +2188,15 @@ class BotDataViewer:
                 start_time = self.db_manager.get_bot_start_time()
                 if start_time:
                     health_data['uptime_seconds'] = time.time() - start_time
+
+                # Inject zombie radio state from shared metadata
+                radio_zombie = self.db_manager.get_metadata('bot.radio_zombie') == 'true'
+                health_data['radio_zombie'] = radio_zombie
+                health_data['radio_zombie_since'] = (
+                    self.db_manager.get_metadata('bot.radio_zombie_since') or None
+                )
+                if radio_zombie:
+                    health_data['status'] = 'degraded'
 
                 return jsonify(health_data)
 
@@ -3090,7 +3459,11 @@ class BotDataViewer:
                                                    fallback='{emoji} {body|truncate:100} - {date}\n{link|truncate:50}')
 
                 # Fetch and format feed items
-                preview_items = self._preview_feed_items(feed_url, feed_type, output_format, api_config, filter_config, sort_config)
+                try:
+                    preview_items = self._preview_feed_items(feed_url, feed_type, output_format, api_config, filter_config, sort_config)
+                except ValueError as e:
+                    # SSRF validation error - return 400
+                    return jsonify({'error': str(e)}), 400
 
                 return jsonify({
                     'success': True,
@@ -3108,14 +3481,13 @@ class BotDataViewer:
                 if not data or 'url' not in data:
                     return jsonify({'error': 'URL is required'}), 400
 
-                # This would require feed_manager - for now just validate URL
-                from urllib.parse import urlparse
                 url = data['url']
-                result = urlparse(url)
-                if not all([result.scheme in ['http', 'https'], result.netloc]):
-                    return jsonify({'error': 'Invalid URL format'}), 400
 
-                return jsonify({'success': True, 'message': 'URL validated (full test requires feed manager)'})
+                # Validate URL for SSRF protection
+                if not validate_external_url(url):
+                    return jsonify({'error': 'Invalid or unsafe URL'}), 400
+
+                return jsonify({'success': True, 'message': 'URL validated'})
             except Exception as e:
                 self.logger.error(f"Error testing feed: {e}")
                 return jsonify({'error': str(e)}), 500
@@ -3519,7 +3891,7 @@ class BotDataViewer:
                     for row in rows:
                         try:
                             emit('command_data', json.loads(row['data']))
-                        except Exception:
+                        except (json.JSONDecodeError, KeyError, TypeError):
                             pass
                 except Exception as e:
                     self.logger.warning(f"Error replaying command history: {e}", exc_info=True)
@@ -3552,7 +3924,7 @@ class BotDataViewer:
                             data = json.loads(row['data'])
                             evt = 'command_data' if row['type'] == 'command' else 'packet_data'
                             emit(evt, data)
-                        except Exception:
+                        except (json.JSONDecodeError, KeyError, TypeError):
                             pass
                 except Exception as e:
                     self.logger.warning(f"Error replaying packet history: {e}", exc_info=True)
@@ -3596,7 +3968,7 @@ class BotDataViewer:
                     for row in rows:
                         try:
                             emit('message_data', json.loads(row['data']))
-                        except Exception:
+                        except (json.JSONDecodeError, KeyError, TypeError):
                             pass
                 except Exception as e:
                     self.logger.warning(f"Error replaying message history: {e}", exc_info=True)
@@ -3619,7 +3991,7 @@ class BotDataViewer:
                     log_file = self.config.get('Logging', 'log_file', fallback='').strip()
                     if log_file:
                         log_file = str(resolve_path(log_file, self._config_base))
-                except Exception:
+                except (configparser.Error, OSError, ValueError):  # bad config or inaccessible path
                     pass
                 if log_file and os.path.exists(log_file):
                     try:
@@ -3976,7 +4348,7 @@ class BotDataViewer:
         except Exception as e:
             self.logger.error(f"Error cleaning up stale clients: {e}")
 
-    def _cleanup_old_data(self, days_to_keep: Optional[int] = None):
+    def _cleanup_old_data(self, days_to_keep: int | None = None):
         """Clean up old packet stream data to prevent database bloat.
         Uses [Data_Retention] packet_stream_retention_days when days_to_keep is not provided."""
         try:
@@ -4039,6 +4411,9 @@ class BotDataViewer:
             # Get all available tables
             cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
             tables = [row[0] for row in cursor.fetchall()]
+
+            # Filter tables by ALLOWED_TABLES whitelist for security
+            tables = [t for t in tables if t in self.ALLOWED_TABLES]
 
             with self._clients_lock:
                 client_count = len(self.connected_clients)
@@ -4254,8 +4629,8 @@ class BotDataViewer:
                 try:
                     validate_sql_identifier(table)
                 except ValueError:
-                    self.logger.warning(f"Skipping invalid table name: {table!r}")
-                    continue
+                    self.logger.warning(f"Rejecting invalid table name: {table!r}")
+                    raise
                 cursor.execute(f"SELECT COUNT(*) FROM {table}")
                 count = cursor.fetchone()[0]
                 stats['total_cache_entries'] += count
@@ -4530,16 +4905,17 @@ class BotDataViewer:
             cursor.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
             table_names = [row[0] for row in cursor.fetchall()]
 
+            # Filter tables by ALLOWED_TABLES whitelist for security
+            table_names = [
+                name for name in table_names
+                if name in self.ALLOWED_TABLES
+            ]
+
             # Get table information
             tables = []
             total_records = 0
 
             for table_name in table_names:
-                try:
-                    validate_sql_identifier(table_name)
-                except ValueError:
-                    self.logger.warning(f"Skipping invalid table name: {table_name!r}")
-                    continue
                 try:
                     # Get record count
                     cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
@@ -4607,6 +4983,19 @@ class BotDataViewer:
             if conn:
                 conn.close()
 
+    def _is_safe_table_name(self, table_name: str) -> bool:
+        """Check if table name is in the ALLOWED_TABLES whitelist.
+
+        Args:
+            table_name: The table name to validate
+
+        Returns:
+            True if the table is in the allowed whitelist, False otherwise
+        """
+        if not table_name or not isinstance(table_name, str):
+            return False
+        return table_name in self.ALLOWED_TABLES
+
     def _get_table_description(self, table_name):
         """Get human-readable description for table"""
         descriptions = {
@@ -4646,17 +5035,13 @@ class BotDataViewer:
             cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
             tables = [row[0] for row in cursor.fetchall()]
 
+            # Filter tables by ALLOWED_TABLES whitelist for security
+            tables = [t for t in tables if t in self.ALLOWED_TABLES]
+
             # Perform REINDEX on all tables
             self.logger.info("Starting database REINDEX...")
             reindexed_tables = []
             for table in tables:
-                if table == 'sqlite_sequence':  # Skip system tables
-                    continue
-                try:
-                    validate_sql_identifier(table)
-                except ValueError:
-                    self.logger.warning(f"Skipping invalid table name for REINDEX: {table!r}")
-                    continue
                 try:
                     cursor.execute(f"REINDEX {table}")
                     reindexed_tables.append(table)
@@ -4744,7 +5129,7 @@ class BotDataViewer:
         return n
 
     def _collect_multibyte_hop_chunks(
-        self, cursor, recent_days: Optional[int] = None
+        self, cursor, recent_days: int | None = None
     ) -> set[str]:
         """Hop prefixes from multibyte paths in observed_paths (for repeater/room pubkey matching).
 
@@ -4784,12 +5169,12 @@ class BotDataViewer:
         row: Any,
         all_paths: list[dict[str, Any]],
         multibyte_hop_chunks: set[str],
-    ) -> Optional[str]:
+    ) -> str | None:
         """Return 'multibyte', 'one_byte', or None for contacts path-encoding badge."""
         pk = row["public_key"] or ""
         role = (row["role"] or "").lower()
         obph_raw = row["out_bytes_per_hop"]
-        obph: Optional[int]
+        obph: int | None
         try:
             obph = int(obph_raw) if obph_raw is not None else None
         except (TypeError, ValueError):
@@ -4846,7 +5231,7 @@ class BotDataViewer:
     def _contact_has_multibyte_path_evidence(
         self,
         public_key: str,
-        role: Optional[str],
+        role: str | None,
         out_bytes_per_hop: Any,
         multibyte_advert_public_keys: set[str],
         multibyte_hop_chunks: set[str],
@@ -4854,7 +5239,7 @@ class BotDataViewer:
         """Multibyte detection for dashboard 7d stats (observed_paths scoped by date in SQL)."""
         pk = public_key or ""
         role_l = (role or "").lower()
-        obph: Optional[int]
+        obph: int | None
         try:
             obph = int(out_bytes_per_hop) if out_bytes_per_hop is not None else None
         except (TypeError, ValueError):
@@ -4885,18 +5270,19 @@ class BotDataViewer:
             bot_lon = self.config.getfloat('Bot', 'bot_longitude', fallback=None)
 
             # Filter by last_heard for performance (default: last 30 days)
+            # Note: last_heard is stored as Unix timestamp (float), so use strftime('%s', ...) for comparison
             if since == 'all':
                 where_clause = ''
                 params = ()
             else:
                 if since == '24h':
-                    where_clause = " WHERE c.last_heard >= datetime('now', '-24 hours')"
+                    where_clause = " WHERE c.last_heard >= strftime('%s', 'now', '-24 hours')"
                 elif since == '7d':
-                    where_clause = " WHERE c.last_heard >= datetime('now', '-7 days')"
+                    where_clause = " WHERE c.last_heard >= strftime('%s', 'now', '-7 days')"
                 elif since == '30d':
-                    where_clause = " WHERE c.last_heard >= datetime('now', '-30 days')"
+                    where_clause = " WHERE c.last_heard >= strftime('%s', 'now', '-30 days')"
                 else:  # 90d
-                    where_clause = " WHERE c.last_heard >= datetime('now', '-90 days')"
+                    where_clause = " WHERE c.last_heard >= strftime('%s', 'now', '-90 days')"
                 params = ()
 
             # Query with LEFT JOIN to a limited set of paths per contact (max 50 most recent per contact)
@@ -5695,15 +6081,19 @@ class BotDataViewer:
             if conn:
                 conn.close()
 
-    def _preview_feed_items(self, feed_url: str, feed_type: str, output_format: str, api_config: Optional[dict[str, Any]] = None, filter_config: Optional[dict[str, Any]] = None, sort_config: Optional[dict[str, Any]] = None) -> list[dict[str, Any]]:
+    def _preview_feed_items(self, feed_url: str, feed_type: str, output_format: str, api_config: dict[str, Any] | None = None, filter_config: dict[str, Any] | None = None, sort_config: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         """Preview feed items with custom output format (standalone, doesn't require bot)"""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         import feedparser
         import requests
 
         try:
             items = []
+
+            # Validate URL for SSRF protection
+            if not validate_external_url(feed_url):
+                raise ValueError("Invalid or unsafe feed URL")
 
             if feed_type == 'rss':
                 # Fetch RSS feed
@@ -5902,10 +6292,9 @@ class BotDataViewer:
 
         return item_passes_filter_config(item, filter_config)
 
-    def _parse_microsoft_date(self, date_str: str) -> Optional[datetime]:
+    def _parse_microsoft_date(self, date_str: str) -> datetime | None:
         """Parse Microsoft JSON date format: /Date(timestamp-offset)/"""
         import re
-        from datetime import timezone
 
         if not date_str or not isinstance(date_str, str):
             return None
@@ -6033,7 +6422,7 @@ class BotDataViewer:
         """Format a feed item using the output format (standalone version)"""
         import html
         import re
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         # Extract field values (NULL/missing fields must not become None for str ops)
         title = item.get('title') or 'Untitled'
@@ -6511,7 +6900,7 @@ class BotDataViewer:
                 'error': str(e)
             }
 
-    def _decode_path_hex(self, path_hex: str, bytes_per_hop: Optional[int] = None) -> list[dict[str, Any]]:
+    def _decode_path_hex(self, path_hex: str, bytes_per_hop: int | None = None) -> list[dict[str, Any]]:
         """
         Decode hex path string to repeater names using the same sophisticated logic as path command.
         Returns a list of dictionaries with node_id and repeater info.
@@ -6564,7 +6953,7 @@ class BotDataViewer:
                     bot_latitude = lat
                     bot_longitude = lon
                     geographic_guessing_enabled = True
-        except Exception:
+        except (ValueError, configparser.Error):  # malformed float or missing section
             pass
 
         self.config.get('Path_Command', 'proximity_method', fallback='simple')
@@ -6875,8 +7264,8 @@ class BotDataViewer:
                                         path_validation_bonus = min(graph_path_validation_max_bonus, path_validation_bonus)
                                         if path_validation_bonus >= graph_path_validation_max_bonus * 0.9:
                                             break  # Strong match found, no need to check more
-                    except Exception:
-                        pass
+                    except (sqlite3.Error, OSError, KeyError, ValueError) as _score_err:
+                        self.logger.debug("Path-scoring graph query failed: %s", _score_err)
 
                 candidate_score = min(1.0, candidate_score + path_validation_bonus)
 
@@ -7128,6 +7517,7 @@ class BotDataViewer:
     def run(self, host='127.0.0.1', port=8080, debug=False):
         """Run the modern web viewer"""
         self.logger.info(f"Starting modern web viewer on {host}:{port}")
+        self._suppress_werkzeug_headers_error()
         try:
             self.socketio.run(
                 self.app,
@@ -7139,6 +7529,26 @@ class BotDataViewer:
         except Exception as e:
             self.logger.error(f"Error running web viewer: {e}")
             raise
+
+    @staticmethod
+    def _suppress_werkzeug_headers_error() -> None:
+        """Install a log filter that silences the 'Headers already set' AssertionError.
+
+        Werkzeug's dev server catches this internally and continues serving, but it
+        logs a full traceback at ERROR level.  The underlying cause (concurrent
+        SocketIO polling requests racing through the WSGI layer) is reduced by the
+        single-socket-per-page fix, but may still occur occasionally.  The filter
+        downgrades these specific records to DEBUG so they don't alarm operators.
+        """
+        import logging
+
+        class _HeadersAlreadySetFilter(logging.Filter):
+            def filter(self, record: logging.LogRecord) -> bool:
+                msg = record.getMessage()
+                return "Headers already set" not in msg
+
+        for name in ("werkzeug", "werkzeug.serving"):
+            logging.getLogger(name).addFilter(_HeadersAlreadySetFilter())
 
 def main():
     """Entry point for the meshcore-viewer command"""

--- a/modules/web_viewer/integration.py
+++ b/modules/web_viewer/integration.py
@@ -58,6 +58,9 @@ class BotIntegration:
         self.circuit_breaker_failures = 0
         self.circuit_breaker_last_failure_time = 0.0
         self.is_shutting_down = False
+        # Configurable HTTP timeouts (seconds) for internal web viewer API calls
+        self._stream_timeout: float = bot.config.getfloat('Web_Viewer', 'stream_timeout', fallback=1.0)
+        self._admin_timeout: float = bot.config.getfloat('Web_Viewer', 'admin_timeout', fallback=0.5)
         # Batched write queue: avoids a per-insert sqlite3.connect() round-trip
         self._write_queue: queue.Queue = queue.Queue()
         self._drain_stop = threading.Event()
@@ -463,14 +466,14 @@ class BotIntegration:
             }
             if self.http_session:
                 try:
-                    self.http_session.post(url, json=payload, timeout=1.0)
+                    self.http_session.post(url, json=payload, timeout=self._stream_timeout)
                     self._record_web_viewer_result(True)
                 except Exception:
                     self._record_web_viewer_result(False)
             else:
                 import requests
                 try:
-                    requests.post(url, json=payload, timeout=1.0, headers=headers)
+                    requests.post(url, json=payload, timeout=self._stream_timeout, headers=headers)
                     self._record_web_viewer_result(True)
                 except Exception:
                     self._record_web_viewer_result(False)
@@ -498,7 +501,7 @@ class BotIntegration:
                 'X-Requested-With': 'BotIntegration',
             }
             try:
-                requests.post(url, json=payload, timeout=0.5, headers=headers)
+                requests.post(url, json=payload, timeout=self._admin_timeout, headers=headers)
                 self._record_web_viewer_result(True)
             except Exception:
                 self._record_web_viewer_result(False)

--- a/modules/web_viewer/templates/admin_config.html
+++ b/modules/web_viewer/templates/admin_config.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block title %}Raw Config — MeshCore Bot{% endblock %}
+
+{% block content %}
+<div class="row mb-3 align-items-center">
+    <div class="col">
+        <h2><i class="fas fa-file-code me-2"></i>Raw Config</h2>
+        <p class="text-muted mb-0">
+            Effective values read from <code>{{ config_path }}</code>.
+            Sensitive fields (passwords, keys, tokens) are redacted.
+        </p>
+    </div>
+    <div class="col-auto">
+        <input type="text" id="cfg-filter" class="form-control form-control-sm"
+               placeholder="Filter keys…" style="min-width:200px">
+    </div>
+</div>
+
+{% if sections %}
+    {% for section, values in sections.items() %}
+    <div class="card mb-3 cfg-section">
+        <div class="card-header py-2">
+            <code class="fw-bold">[{{ section }}]</code>
+        </div>
+        <div class="card-body p-0">
+            <table class="table table-sm table-hover mb-0">
+                <tbody>
+                {% for key, value in values.items() %}
+                <tr class="cfg-row" data-key="{{ key }}" data-section="{{ section }}">
+                    <td class="ps-3 text-nowrap" style="width:35%;font-family:monospace">{{ key }}</td>
+                    <td style="font-family:monospace;word-break:break-all">
+                        {% if value == '●●●●●●' %}
+                            <span class="text-muted fst-italic">{{ value }}</span>
+                        {% elif value == '' %}
+                            <span class="text-muted fst-italic">(empty)</span>
+                        {% else %}
+                            {{ value }}
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {% endfor %}
+{% else %}
+    <div class="alert alert-warning">No config sections found — check that <code>{{ config_path }}</code> exists and is readable.</div>
+{% endif %}
+
+<script>
+(function () {
+    var input = document.getElementById('cfg-filter');
+    input.addEventListener('input', function () {
+        var q = this.value.trim().toLowerCase();
+        document.querySelectorAll('.cfg-section').forEach(function (section) {
+            var rows = section.querySelectorAll('.cfg-row');
+            var anyVisible = false;
+            rows.forEach(function (row) {
+                var key = (row.dataset.key + ' ' + row.dataset.section).toLowerCase();
+                var text = row.textContent.toLowerCase();
+                var match = !q || key.includes(q) || text.includes(q);
+                row.style.display = match ? '' : 'none';
+                if (match) anyVisible = true;
+            });
+            section.style.display = anyVisible ? '' : 'none';
+        });
+    });
+})();
+</script>
+{% endblock %}

--- a/modules/web_viewer/templates/base.html
+++ b/modules/web_viewer/templates/base.html
@@ -431,6 +431,16 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="/api-explorer">
+                            <i class="fas fa-plug"></i> API
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/admin/config">
+                            <i class="fas fa-file-code"></i> Raw Config
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/logs">
                             <i class="fas fa-file-alt"></i> Logs
                         </a>
@@ -455,6 +465,166 @@
         </div>
     </nav>
     
+    <!-- Bot Initializing Banner (shown while bot is connecting to radio at startup) -->
+    <div id="init-banner" class="alert alert-info mb-0 rounded-0 border-0 border-bottom border-info{% if not bot_initializing %} d-none{% endif %}" role="alert" style="border-width: 2px !important;">
+        <div class="container-fluid">
+            <i class="fas fa-spinner fa-spin me-2"></i>
+            <strong>Bot Initializing</strong> — connecting to radio hardware. The web viewer is available but bot commands are not yet active.
+        </div>
+    </div>
+
+    <!-- Zombie Radio Banner (persistent — shown on all pages when radio is in zombie state) -->
+    <div id="zombie-banner" class="alert alert-danger mb-0 rounded-0 border-0 border-bottom border-danger{% if not radio_zombie %} d-none{% endif %}" role="alert" style="border-width: 2px !important;">
+        <div class="container-fluid">
+            <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+                <div>
+                    <i class="fas fa-skull-crossbones me-2"></i>
+                    <strong>Radio Zombie State Detected</strong> — The bot radio firmware is unresponsive.
+                    A physical <strong>power cycle</strong> of the radio hardware is required.
+                    Disconnect/reconnect will <em>not</em> fix this.
+                    <span id="zombie-since-span" class="ms-3 text-danger-emphasis small opacity-75{% if not radio_zombie_since %} d-none{% endif %}">
+                        <i class="fas fa-clock me-1"></i>Since: <span id="zombie-since-text">{{ radio_zombie_since or '' }}</span>
+                    </span>
+                </div>
+                <div class="d-flex gap-2 align-items-center flex-shrink-0">
+                    <span class="small opacity-75">After power cycling:</span>
+                    <button id="zombie-recover-btn" class="btn btn-warning btn-sm fw-semibold"
+                            onclick="zombieRecover()" type="button">
+                        <i class="fas fa-power-off me-1"></i>Restart Bot Processing
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Radio Offline Banner (shown when repeated send timeouts have entered the offline state) -->
+    <div id="offline-banner" class="alert alert-warning mb-0 rounded-0 border-0 border-bottom border-warning{% if not radio_offline %} d-none{% endif %}" role="alert" style="border-width: 2px !important;">
+        <div class="container-fluid">
+            <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+                <div>
+                    <i class="fas fa-plug me-2"></i>
+                    <strong>Radio Offline</strong> — the bot cannot send outbound messages to the mesh.
+                    Check radio power and connection. Inbound packets may still be arriving normally.
+                    <span id="offline-since-span" class="ms-3 text-warning-emphasis small opacity-75{% if not radio_offline_since %} d-none{% endif %}">
+                        <i class="fas fa-clock me-1"></i>Since: <span id="offline-since-text">{{ radio_offline_since or '' }}</span>
+                    </span>
+                </div>
+                <div class="d-flex gap-2 align-items-center flex-shrink-0">
+                    <span class="small opacity-75">Once radio is fixed:</span>
+                    <button id="offline-clear-btn" class="btn btn-dark btn-sm fw-semibold"
+                            onclick="radioOfflineClear()" type="button">
+                        <i class="fas fa-check me-1"></i>Clear Offline Flag
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    // Global 401 interceptor: redirect to login when session expires mid-page.
+    // Wraps window.fetch so all AJAX calls in every template are covered.
+    (function() {
+        var _origFetch = window.fetch;
+        window.fetch = function(url, options) {
+            return _origFetch.apply(this, arguments).then(function(response) {
+                if (response.status === 401 && typeof url === 'string' && url.startsWith('/api/')) {
+                    var next = encodeURIComponent(window.location.pathname + window.location.search);
+                    window.location.href = '/login?next=' + next;
+                }
+                return response;
+            });
+        };
+    })();
+
+    // Banner action: zombie recover
+    function zombieRecover() {
+        var btn = document.getElementById('zombie-recover-btn');
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Restarting\u2026';
+        fetch('/api/admin/zombie-recover', {method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}})
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                var b = document.getElementById('zombie-banner');
+                b.className = 'alert alert-success mb-0 rounded-0 border-0 border-bottom border-success';
+                b.innerHTML = '<div class="container-fluid"><i class="fas fa-check-circle me-2"></i>' +
+                    '<strong>Reconnect scheduled.</strong> Refresh this page in a few seconds to confirm the radio is back online.</div>';
+            } else {
+                btn.disabled = false;
+                btn.innerHTML = '<i class="fas fa-power-off me-1"></i>Restart Bot Processing';
+                alert('Error: ' + (data.error || 'Unknown error \u2014 check server logs'));
+            }
+        })
+        .catch(function() {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-power-off me-1"></i>Restart Bot Processing';
+            alert('Network error \u2014 could not reach the server.');
+        });
+    }
+
+    // Banner action: radio offline clear
+    function radioOfflineClear() {
+        var btn = document.getElementById('offline-clear-btn');
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Clearing\u2026';
+        fetch('/api/admin/radio-offline-clear', {method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}})
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                var b = document.getElementById('offline-banner');
+                b.className = 'alert alert-success mb-0 rounded-0 border-0 border-bottom border-success';
+                b.innerHTML = '<div class="container-fluid"><i class="fas fa-check-circle me-2"></i>' +
+                    '<strong>Offline flag cleared.</strong> The bot will resume outbound sends. Refresh to confirm.</div>';
+            } else {
+                btn.disabled = false;
+                btn.innerHTML = '<i class="fas fa-check me-1"></i>Clear Offline Flag';
+                alert('Error: ' + (data.error || 'Unknown error \u2014 check server logs'));
+            }
+        })
+        .catch(function() {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-check me-1"></i>Clear Offline Flag';
+            alert('Network error \u2014 could not reach the server.');
+        });
+    }
+
+    // Live banner polling — updates all banners every 10s without a page reload
+    (function() {
+        function applyBannerStatus(d) {
+            var show = function(id) { var el = document.getElementById(id); if (el) el.classList.remove('d-none'); };
+            var hide = function(id) { var el = document.getElementById(id); if (el) el.classList.add('d-none'); };
+            var setText = function(id, v) { var el = document.getElementById(id); if (el) el.textContent = v || ''; };
+
+            d.bot_initializing ? show('init-banner') : hide('init-banner');
+
+            if (d.radio_zombie) {
+                show('zombie-banner');
+                if (d.radio_zombie_since) { setText('zombie-since-text', d.radio_zombie_since); show('zombie-since-span'); }
+                else { hide('zombie-since-span'); }
+            } else {
+                hide('zombie-banner');
+            }
+
+            if (d.radio_offline) {
+                show('offline-banner');
+                if (d.radio_offline_since) { setText('offline-since-text', d.radio_offline_since); show('offline-since-span'); }
+                else { hide('offline-since-span'); }
+            } else {
+                hide('offline-banner');
+            }
+        }
+
+        function pollBanners() {
+            fetch('/api/banner-status')
+            .then(function(r) { return r.json(); })
+            .then(applyBannerStatus)
+            .catch(function() {});  // silent — server may be restarting
+        }
+
+        setInterval(pollBanners, 10000);
+    })();
+    </script>
+
     <!-- Main Content -->
     <div class="container-fluid mt-4">
         {% block content %}{% endblock %}
@@ -682,13 +852,14 @@
             }
         }
 
-        // Initialize connection manager when page loads
+        // Create connection manager synchronously so page scripts in the extra_js
+        // block can share the same socket without calling io() a second time.
+        window.connectionManager = new ModernConnectionManager();
+
         document.addEventListener('DOMContentLoaded', () => {
             // Initialize dark mode manager first
             window.darkModeManager = new DarkModeManager();
-            
-            window.connectionManager = new ModernConnectionManager();
-            
+
             // Update timestamp immediately and every second
             updateTimestamp();
             setInterval(updateTimestamp, 1000);

--- a/tests/integration/test_flood_scope_reply.py
+++ b/tests/integration/test_flood_scope_reply.py
@@ -10,7 +10,7 @@ These tests verify the full chain:
 import configparser
 import hmac as hmac_mod
 from hashlib import sha256
-from unittest.mock import AsyncMock, MagicMock, Mock, call
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 

--- a/tests/test_meshcore_bot_cli.py
+++ b/tests/test_meshcore_bot_cli.py
@@ -1,9 +1,9 @@
 """Tests for meshcore_bot.py CLI flags (--show-config, --validate-config)."""
 
+import os
 import subprocess
 import sys
 import tempfile
-import os
 
 
 def _write_config(content: str) -> str:

--- a/tests/test_meshcore_bot_cli.py
+++ b/tests/test_meshcore_bot_cli.py
@@ -1,0 +1,64 @@
+"""Tests for meshcore_bot.py CLI flags (--show-config, --validate-config)."""
+
+import subprocess
+import sys
+import tempfile
+import os
+
+
+def _write_config(content: str) -> str:
+    """Write a temp config.ini and return its path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+
+SAMPLE_CONFIG = """
+[Bot]
+bot_name = TestBot
+db_path = test.db
+
+[Web_Viewer]
+host = 127.0.0.1
+port = 8080
+"""
+
+
+class TestShowConfig:
+    def test_outputs_sections_and_keys(self):
+        cfg_path = _write_config(SAMPLE_CONFIG)
+        try:
+            result = subprocess.run(
+                [sys.executable, "meshcore_bot.py", "--config", cfg_path, "--show-config"],
+                capture_output=True, text=True, timeout=10,
+            )
+            assert result.returncode == 0
+            assert "[Bot]" in result.stdout
+            assert "bot_name = TestBot" in result.stdout
+            assert "[Web_Viewer]" in result.stdout
+            assert "port = 8080" in result.stdout
+        finally:
+            os.unlink(cfg_path)
+
+    def test_exits_zero(self):
+        cfg_path = _write_config(SAMPLE_CONFIG)
+        try:
+            result = subprocess.run(
+                [sys.executable, "meshcore_bot.py", "--config", cfg_path, "--show-config"],
+                capture_output=True, text=True, timeout=10,
+            )
+            assert result.returncode == 0
+        finally:
+            os.unlink(cfg_path)
+
+    def test_includes_config_filename_comment(self):
+        cfg_path = _write_config(SAMPLE_CONFIG)
+        try:
+            result = subprocess.run(
+                [sys.executable, "meshcore_bot.py", "--config", cfg_path, "--show-config"],
+                capture_output=True, text=True, timeout=10,
+            )
+            assert cfg_path in result.stdout
+        finally:
+            os.unlink(cfg_path)

--- a/tests/test_plugins_command.py
+++ b/tests/test_plugins_command.py
@@ -1,0 +1,87 @@
+"""Tests for modules.commands.plugins_command."""
+
+import configparser
+from unittest.mock import MagicMock, Mock
+
+from modules.commands.plugins_command import PluginsCommand
+from tests.conftest import mock_message
+
+
+def _make_bot(services=None):
+    bot = MagicMock()
+    bot.logger = Mock()
+    config = configparser.ConfigParser()
+    config.add_section("Bot")
+    config.set("Bot", "bot_name", "TestBot")
+    config.add_section("Channels")
+    config.set("Channels", "monitor_channels", "general")
+    config.set("Channels", "respond_to_dms", "true")
+    config.add_section("Keywords")
+    bot.config = config
+    bot.translator = MagicMock()
+    bot.translator.translate = Mock(side_effect=lambda key, **kw: key)
+    bot.command_manager = MagicMock()
+    bot.command_manager.monitor_channels = ["general"]
+    bot.services = services if services is not None else {}
+    return bot
+
+
+class TestPluginsCommandBuild:
+    def test_no_services(self):
+        cmd = PluginsCommand(_make_bot())
+        result = cmd._build_list()
+        assert "No service plugins loaded" in result
+
+    def test_single_service_with_description(self):
+        svc = MagicMock()
+        svc.description = "Sends earthquake alerts"
+        bot = _make_bot({"earthquake": svc})
+        cmd = PluginsCommand(bot)
+        result = cmd._build_list()
+        assert "earthquake" in result
+        assert "Sends earthquake alerts" in result
+
+    def test_single_service_no_description(self):
+        svc = MagicMock()
+        svc.description = ""
+        bot = _make_bot({"discord": svc})
+        cmd = PluginsCommand(bot)
+        result = cmd._build_list()
+        assert "discord" in result
+
+    def test_multiple_services_sorted(self):
+        a = MagicMock()
+        a.description = "A service"
+        b = MagicMock()
+        b.description = "B service"
+        bot = _make_bot({"zebra": a, "alpha": b})
+        cmd = PluginsCommand(bot)
+        result = cmd._build_list()
+        assert result.index("alpha") < result.index("zebra")
+
+    def test_description_truncated_at_60(self):
+        svc = MagicMock()
+        svc.description = "x" * 80
+        bot = _make_bot({"svc": svc})
+        cmd = PluginsCommand(bot)
+        result = cmd._build_list()
+        assert "..." in result
+
+    def test_header_shows_count(self):
+        a = MagicMock()
+        a.description = "a"
+        b = MagicMock()
+        b.description = "b"
+        bot = _make_bot({"a": a, "b": b})
+        cmd = PluginsCommand(bot)
+        result = cmd._build_list()
+        assert "Plugins (2)" in result
+
+    def test_disabled_returns_false(self):
+        bot = _make_bot()
+        bot.config.add_section("Plugins_Command")
+        bot.config.set("Plugins_Command", "enabled", "false")
+        cmd = PluginsCommand(bot)
+        import asyncio
+        result = asyncio.run(cmd.execute(mock_message()))
+        assert result is False

--- a/tests/test_plugins_command.py
+++ b/tests/test_plugins_command.py
@@ -85,3 +85,35 @@ class TestPluginsCommandBuild:
         import asyncio
         result = asyncio.run(cmd.execute(mock_message()))
         assert result is False
+
+
+class TestPluginsCommandExecute:
+    """Cover the execute() success path and services exception path."""
+
+    def test_execute_success_returns_true(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+        from unittest.mock import patch as _patch
+        bot = _make_bot()
+        cmd = PluginsCommand(bot)
+        with _patch.object(cmd, "send_response", new=AsyncMock(return_value=True)):
+            result = asyncio.run(cmd.execute(mock_message()))
+        assert result is True
+
+    def test_execute_exception_returns_false(self):
+        import asyncio
+        from unittest.mock import patch as _patch
+        bot = _make_bot()
+        cmd = PluginsCommand(bot)
+        with _patch.object(cmd, "_build_list", side_effect=RuntimeError("oops")):
+            result = asyncio.run(cmd.execute(mock_message()))
+        assert result is False
+
+    def test_build_list_services_exception_returns_no_plugins(self):
+        bot = _make_bot()
+        type(bot).services = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("gone"))
+        )
+        cmd = PluginsCommand(bot)
+        result = cmd._build_list()
+        assert "No service plugins loaded" in result

--- a/tests/test_status_command.py
+++ b/tests/test_status_command.py
@@ -114,3 +114,91 @@ class TestStatusCommandIsCallable:
         cmd = StatusCommand(bot)
         result = cmd._build_status()
         assert "Radio: OFFLINE" in result
+
+
+class TestStatusCommandEdgeCases:
+    """Cover missing branches: uptime minutes-only, DB size KB/B, exception paths."""
+
+    def _cmd(self, **kwargs):
+        return StatusCommand(_make_bot(**kwargs))
+
+    def test_uptime_minutes_only(self):
+        cmd = self._cmd(start_time=time.time() - 1800)  # 30 min
+        result = cmd._build_status()
+        assert "30m" in result
+        assert "h" not in result.split("Up:")[1].split("\n")[0]
+
+    def test_uptime_unknown_when_no_start_time(self):
+        bot = _make_bot()
+        bot.start_time = None
+        cmd = StatusCommand(bot)
+        result = cmd._build_status()
+        assert "Up: unknown" in result
+
+    def test_db_size_kb(self):
+        from unittest.mock import patch as _patch
+        bot = _make_bot()
+        bot.db_manager.db_path = "/fake/path.db"
+        cmd = StatusCommand(bot)
+        with _patch("os.path.getsize", return_value=2048):
+            result = cmd._build_status()
+        assert "KB" in result
+
+    def test_db_size_bytes(self):
+        from unittest.mock import patch as _patch
+        bot = _make_bot()
+        bot.db_manager.db_path = "/fake/path.db"
+        cmd = StatusCommand(bot)
+        with _patch("os.path.getsize", return_value=512):
+            result = cmd._build_status()
+        assert "B" in result and "KB" not in result and "MB" not in result
+
+    def test_channels_exception_is_silent(self):
+        bot = _make_bot()
+        type(bot.command_manager).monitor_channels = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("gone"))
+        )
+        cmd = StatusCommand(bot)
+        result = cmd._build_status()  # must not raise
+        assert "Up:" in result
+
+    def test_services_exception_is_silent(self):
+        bot = _make_bot()
+        type(bot).services = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("gone"))
+        )
+        cmd = StatusCommand(bot)
+        result = cmd._build_status()  # must not raise
+        assert "Up:" in result
+
+
+class TestStatusCommandExecute:
+    """Cover the execute() async method paths."""
+
+    def test_execute_success_returns_true(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+        from unittest.mock import patch as _patch
+        bot = _make_bot()
+        cmd = StatusCommand(bot)
+        with _patch.object(cmd, "send_response", new=AsyncMock(return_value=True)):
+            result = asyncio.run(cmd.execute(mock_message()))
+        assert result is True
+
+    def test_execute_exception_returns_false(self):
+        import asyncio
+        from unittest.mock import patch as _patch
+        bot = _make_bot()
+        cmd = StatusCommand(bot)
+        with _patch.object(cmd, "_build_status", side_effect=RuntimeError("oops")):
+            result = asyncio.run(cmd.execute(mock_message()))
+        assert result is False
+
+    def test_db_size_mb(self):
+        from unittest.mock import patch as _patch
+        bot = _make_bot()
+        bot.db_manager.db_path = "/fake/path.db"
+        cmd = StatusCommand(bot)
+        with _patch("os.path.getsize", return_value=2 * 1_048_576):
+            result = cmd._build_status()
+        assert "MB" in result

--- a/tests/test_status_command.py
+++ b/tests/test_status_command.py
@@ -1,0 +1,116 @@
+"""Tests for modules.commands.status_command."""
+
+import configparser
+import time
+from unittest.mock import MagicMock, Mock
+
+from modules.commands.status_command import StatusCommand
+from tests.conftest import mock_message
+
+
+def _make_bot(start_time=None):
+    bot = MagicMock()
+    bot.logger = Mock()
+    config = configparser.ConfigParser()
+    config.add_section("Bot")
+    config.set("Bot", "bot_name", "TestBot")
+    config.add_section("Channels")
+    config.set("Channels", "monitor_channels", "general")
+    config.set("Channels", "respond_to_dms", "true")
+    config.add_section("Keywords")
+    bot.config = config
+    bot.translator = MagicMock()
+    bot.translator.translate = Mock(side_effect=lambda key, **kw: key)
+    bot.command_manager = MagicMock()
+    bot.command_manager.monitor_channels = ["general", "local"]
+    bot.start_time = start_time if start_time is not None else time.time() - 3700
+    bot.is_radio_zombie = False
+    bot.is_radio_offline = False
+    bot.services = {}
+    db = MagicMock()
+    db.db_path = ":memory:"
+    bot.db_manager = db
+    return bot
+
+
+class TestStatusCommandBuild:
+    def setup_method(self):
+        self.bot = _make_bot()
+        self.cmd = StatusCommand(self.bot)
+
+    def test_uptime_hours_minutes(self):
+        self.bot.start_time = time.time() - (2 * 3600 + 15 * 60)
+        result = self.cmd._build_status()
+        assert "Up:" in result
+        assert "2h" in result
+
+    def test_uptime_days(self):
+        self.bot.start_time = time.time() - (25 * 3600)
+        result = self.cmd._build_status()
+        assert "1d" in result
+
+    def test_radio_ok(self):
+        self.bot.is_radio_zombie = False
+        self.bot.is_radio_offline = False
+        result = self.cmd._build_status()
+        assert "Radio: ok" in result
+
+    def test_radio_zombie(self):
+        self.bot.is_radio_zombie = True
+        result = self.cmd._build_status()
+        assert "Radio: ZOMBIE" in result
+
+    def test_radio_offline(self):
+        self.bot.is_radio_zombie = False
+        self.bot.is_radio_offline = True
+        result = self.cmd._build_status()
+        assert "Radio: OFFLINE" in result
+
+    def test_channel_count(self):
+        result = self.cmd._build_status()
+        assert "Channels: 2" in result
+
+    def test_services_none(self):
+        self.bot.services = {}
+        result = self.cmd._build_status()
+        assert "Services: none" in result
+
+    def test_services_listed(self):
+        svc = MagicMock()
+        svc.description = "Earthquake alerts"
+        self.bot.services = {"earthquake": svc}
+        result = self.cmd._build_status()
+        assert "Services: 1" in result
+        assert "earthquake" in result
+
+    def test_is_dm_only(self):
+        assert self.cmd.requires_dm is True
+
+    def test_disabled_returns_false(self):
+        self.bot.config.set("Status_Command", "enabled", "false") if self.bot.config.has_section("Status_Command") else None
+        if not self.bot.config.has_section("Status_Command"):
+            self.bot.config.add_section("Status_Command")
+        self.bot.config.set("Status_Command", "enabled", "false")
+        cmd = StatusCommand(self.bot)
+        import asyncio
+        result = asyncio.run(cmd.execute(mock_message()))
+        assert result is False
+
+
+class TestStatusCommandIsCallable:
+    """is_radio_zombie/offline can be properties (bool) or callables."""
+
+    def test_callable_zombie(self):
+        bot = _make_bot()
+        bot.is_radio_zombie = lambda: True
+        cmd = StatusCommand(bot)
+        result = cmd._build_status()
+        assert "Radio: ZOMBIE" in result
+
+    def test_callable_offline(self):
+        bot = _make_bot()
+        bot.is_radio_zombie = lambda: False
+        bot.is_radio_offline = lambda: True
+        cmd = StatusCommand(bot)
+        result = cmd._build_status()
+        assert "Radio: OFFLINE" in result

--- a/tests/test_web_viewer_integration.py
+++ b/tests/test_web_viewer_integration.py
@@ -477,6 +477,30 @@ class TestNormalizedWebViewerPassword:
 # ---------------------------------------------------------------------------
 
 
+class TestConfigurableTimeouts:
+    """stream_timeout and admin_timeout are read from [Web_Viewer] config."""
+
+    def test_default_stream_timeout(self):
+        bi = _make_bot_integration()
+        assert bi._stream_timeout == 1.0
+
+    def test_default_admin_timeout(self):
+        bi = _make_bot_integration()
+        assert bi._admin_timeout == 0.5
+
+    def test_custom_stream_timeout(self):
+        bot = _make_bot()
+        bot.config.set("Web_Viewer", "stream_timeout", "2.5")
+        bi = _make_bot_integration(bot)
+        assert bi._stream_timeout == 2.5
+
+    def test_custom_admin_timeout(self):
+        bot = _make_bot()
+        bot.config.set("Web_Viewer", "admin_timeout", "1.0")
+        bi = _make_bot_integration(bot)
+        assert bi._admin_timeout == 1.0
+
+
 class TestShutdown:
     def test_shutdown_sets_flag(self):
         bi = _make_bot_integration()

--- a/tests/unit/test_log_data_scope_fields.py
+++ b/tests/unit/test_log_data_scope_fields.py
@@ -4,8 +4,6 @@ needed for scope matching (transport_code, pkt_payload, payload_type) in LOG_DAT
 These tests exercise the meshcore library's MeshcorePacketParser directly.
 """
 
-import asyncio
-
 import pytest
 
 # Import the meshcore library parser directly

--- a/tests/unit/test_public_channel_guard.py
+++ b/tests/unit/test_public_channel_guard.py
@@ -1,17 +1,16 @@
 """Unit tests for the Public channel guard."""
 
 import configparser
+from unittest.mock import MagicMock
+
 import pytest
-from unittest.mock import MagicMock, patch
 
 from modules.config_validation import (
     PUBLIC_CHANNEL_KEY_HEX,
     PUBLIC_CHANNEL_OVERRIDE_KEY,
     SEVERITY_ERROR,
     _channel_name_is_public,
-    validate_config,
 )
-
 
 # --- _channel_name_is_public() ---
 


### PR DESCRIPTION
## Summary

- **\`!status\` command**: reports bot uptime, connected radio, firmware version, and active channel count
- **\`!plugins\` command**: lists loaded service plugins and their enabled/disabled state
- **Configurable integration timeouts**: \`[Integration]\` config section allows per-service timeout overrides
- **\`--show-config\` flag**: prints the resolved config (with secrets redacted) at startup and exits
- **\`--show-config-json\` flag**: same as above but outputs JSON for scripting
- **\`/admin/config\` web viewer page**: read-only view of the resolved runtime config in the web UI

## Config changes (\`[Integration]\`)

\`\`\`ini
# Per-service timeout overrides (seconds)
#discord_timeout = 10
#telegram_timeout = 10
\`\`\`

## Test plan

- [ ] Run \`!status\` in a monitored channel — bot replies with uptime and radio info
- [ ] Run \`!plugins\` — bot lists loaded service plugins
- [ ] Run \`python meshcore_bot.py --show-config\` — prints redacted config and exits
- [ ] Navigate to \`/admin/config\` in web viewer — shows runtime config
- [ ] Run \`pytest tests/test_status_command.py tests/test_plugins_command.py tests/test_meshcore_bot_cli.py\`