### PR TITLE
fix: ruff/mypy compliance for issues introduced by PR #152

### DIFF
--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -15,7 +15,7 @@ from meshcore import EventType
 
 from .commands.base_command import BaseCommand
 from .config_validation import (
-    PUBLIC_CHANNEL_KEY_HEX,
+    PUBLIC_CHANNEL_KEY_HEX,  # noqa: F401 — re-exported; imported by core.py
     PUBLIC_CHANNEL_OVERRIDE_KEY,
     _channel_name_is_public,
     strip_optional_quotes,

--- a/modules/commands/multitest_command.py
+++ b/modules/commands/multitest_command.py
@@ -617,9 +617,9 @@ class MultitestCommand(BaseCommand):
         return self.translate('commands.multitest.help', fallback="Listens for 6 seconds and collects all unique paths from incoming messages")
 
     def matches_keyword(self, message: MeshMessage) -> bool:
-        """Check if message matches multitest keyword"""        
+        """Check if message matches multitest keyword"""
         content_lower = self.cleanup_message_for_matching(message)
-                
+
         # Check for exact match or keyword followed by space
         for keyword in self.keywords:
             if content_lower == keyword or content_lower.startswith(keyword + ' '):

--- a/modules/commands/path_command.py
+++ b/modules/commands/path_command.py
@@ -181,7 +181,7 @@ class PathCommand(BaseCommand):
     def matches_keyword(self, message: MeshMessage) -> bool:
         """Check if message starts with 'path' keyword or 'p' shortcut (if enabled)"""
         content_lower = self.cleanup_message_for_matching(message)
-                
+
         # Handle "p" shortcut if enabled
         if self.enable_p_shortcut:
             if content_lower == "p":

--- a/modules/commands/prefix_command.py
+++ b/modules/commands/prefix_command.py
@@ -134,7 +134,7 @@ class PrefixCommand(BaseCommand):
 
     def matches_keyword(self, message: MeshMessage) -> bool:
         """Check if message starts with 'prefix' keyword"""
-        content_lower = self.cleanup_message_for_matching(message)                
+        content_lower = self.cleanup_message_for_matching(message)
         return content_lower == 'prefix' or content_lower.startswith('prefix ')
 
     async def _parse_location_to_lat_lon(self, location: str) -> tuple[Optional[float], Optional[float], Optional[str]]:

--- a/modules/commands/roll_command.py
+++ b/modules/commands/roll_command.py
@@ -74,7 +74,7 @@ class RollCommand(BaseCommand):
             bool: True if the message matches the roll command syntax, False otherwise.
         """
         content_lower = self.cleanup_message_for_matching(message)
-                
+
         # Check for exact "roll" match
         if content_lower == "roll":
             return True

--- a/modules/commands/sports_command.py
+++ b/modules/commands/sports_command.py
@@ -111,9 +111,9 @@ class SportsCommand(BaseCommand):
         """Check if this command matches the message content - sports must be first word"""
         if not self.keywords:
             return False
-        
+
         content_lower = self.cleanup_message_for_matching(message)
-                
+
         # Split into words and check if first word matches any keyword
         words = content_lower.split()
         if not words:

--- a/modules/core.py
+++ b/modules/core.py
@@ -1035,7 +1035,7 @@ long_jokes = false
         # Register signal handlers
         signal.signal(signal.SIGTERM, signal_handler)
         signal.signal(signal.SIGINT, signal_handler)
-    
+
     async def _attempt_reconnect(self) -> bool:
         """Attempt to reconnect to the MeshCore node with exponential backoff.
 

--- a/modules/models.py
+++ b/modules/models.py
@@ -29,6 +29,8 @@ class MeshMessage:
     routing_info: Optional[dict[str, Any]] = None
     # Matched flood scope for the reply (e.g. "#west"), None means global flood
     reply_scope: Optional[str] = None
+    # Lowercased content set by base_command.cleanup_message_for_matching
+    content_lower: str = ""
 
     def effective_outgoing_flood_scope(self, bot: Any) -> str:
         """Resolve outbound flood scope the same way as ``CommandManager.send_channel_message``.

--- a/modules/service_plugins/packet_capture_service.py
+++ b/modules/service_plugins/packet_capture_service.py
@@ -19,10 +19,10 @@ from meshcore import EventType
 
 # Import bot's enums
 from ..enums import PayloadType, PayloadVersion, RouteType
-from ..version_info import resolve_runtime_version
 
 # Import bot's utilities for packet hash
 from ..utils import calculate_packet_hash, decode_path_len_byte, parse_trace_payload_route_hashes
+from ..version_info import resolve_runtime_version
 
 # Import MQTT client
 try:

--- a/modules/version_info.py
+++ b/modules/version_info.py
@@ -13,10 +13,9 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Optional
 
 
-def _normalize_tag(value: Optional[str]) -> Optional[str]:
+def _normalize_tag(value: str | None) -> str | None:
     if not value:
         return None
     value = value.strip()
@@ -25,7 +24,7 @@ def _normalize_tag(value: Optional[str]) -> Optional[str]:
     return value if value.startswith("v") else f"v{value}"
 
 
-def _safe_git_run(repo_root: Path, args: list[str]) -> Optional[str]:
+def _safe_git_run(repo_root: Path, args: list[str]) -> str | None:
     try:
         result = subprocess.run(
             ["git", "-C", str(repo_root)] + args,
@@ -41,7 +40,7 @@ def _safe_git_run(repo_root: Path, args: list[str]) -> Optional[str]:
         return None
 
 
-def _read_version_file(repo_root: Path) -> Optional[str]:
+def _read_version_file(repo_root: Path) -> str | None:
     version_file = repo_root / ".version_info"
     if not version_file.is_file():
         return None
@@ -54,7 +53,7 @@ def _read_version_file(repo_root: Path) -> Optional[str]:
         return None
 
 
-def _read_pyproject_version(repo_root: Path) -> Optional[str]:
+def _read_pyproject_version(repo_root: Path) -> str | None:
     pyproject_path = repo_root / "pyproject.toml"
     if not pyproject_path.is_file():
         return None
@@ -79,7 +78,7 @@ def _read_pyproject_version(repo_root: Path) -> Optional[str]:
     return None
 
 
-def resolve_runtime_version(repo_root: Path | str) -> dict[str, Optional[str]]:
+def resolve_runtime_version(repo_root: Path | str) -> dict[str, str | None]:
     """Resolve version metadata and a single runtime display value.
 
     Returns a dict with:
@@ -103,7 +102,7 @@ def resolve_runtime_version(repo_root: Path | str) -> dict[str, Optional[str]]:
         # %ci format is "YYYY-MM-DD HH:MM:SS +TZ"; keep date only.
         date = date_raw.split()[0] if " " in date_raw else date_raw
 
-    display: Optional[str]
+    display: str | None
     if branch and branch != "main" and commit:
         display = f"{branch}-{commit}"
     elif branch == "main" and baked:

--- a/tests/integration/test_flood_scope_reply.py
+++ b/tests/integration/test_flood_scope_reply.py
@@ -10,7 +10,7 @@ These tests verify the full chain:
 import configparser
 import hmac as hmac_mod
 from hashlib import sha256
-from unittest.mock import AsyncMock, MagicMock, Mock, call
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 

--- a/tests/unit/test_log_data_scope_fields.py
+++ b/tests/unit/test_log_data_scope_fields.py
@@ -4,7 +4,6 @@ needed for scope matching (transport_code, pkt_payload, payload_type) in LOG_DAT
 These tests exercise the meshcore library's MeshcorePacketParser directly.
 """
 
-import asyncio
 
 import pytest
 

--- a/tests/unit/test_public_channel_guard.py
+++ b/tests/unit/test_public_channel_guard.py
@@ -1,17 +1,16 @@
 """Unit tests for the Public channel guard."""
 
 import configparser
+from unittest.mock import MagicMock
+
 import pytest
-from unittest.mock import MagicMock, patch
 
 from modules.config_validation import (
     PUBLIC_CHANNEL_KEY_HEX,
     PUBLIC_CHANNEL_OVERRIDE_KEY,
     SEVERITY_ERROR,
     _channel_name_is_public,
-    validate_config,
 )
-
 
 # --- _channel_name_is_public() ---
 


### PR DESCRIPTION
## Summary

PR #152 introduced several ruff/mypy violations that cause CI failures on all branches that rebase onto `dev` after that merge. This PR fixes them at the source so downstream branches do not need to carry workarounds.

**Linting (ruff):**
- `modules/command_manager.py`: restore `PUBLIC_CHANNEL_KEY_HEX` re-export with `noqa` guard — `core.py` imports it from here and ruff auto-fix silently removed it
- `modules/commands/multitest_command.py`, `path_command.py`, `prefix_command.py`, `roll_command.py`, `sports_command.py`: strip W291/W293 trailing whitespace
- `modules/core.py`: strip W293 blank-line whitespace
- `modules/service_plugins/packet_capture_service.py`: sort imports (I001)
- `modules/version_info.py`: remove unused `typing.Any` import (F401)
- `tests/integration/test_flood_scope_reply.py`: remove unused `call` import (F401)
- `tests/unit/test_log_data_scope_fields.py`: remove unused `asyncio` import (F401)
- `tests/unit/test_public_channel_guard.py`: sort imports and remove unused `patch` / `validate_config` (F401, I001)

**Type checking (mypy):**
- `modules/models.py`: declare `content_lower: str = ""` on `MeshMessage` — PR #152 sets this attribute at runtime in `base_command.cleanup_message_for_matching` without declaring it on the dataclass, causing `attr-defined` errors across all command modules

## Merge order

**Merge this PR before or alongside PRs #155–#158** — those branches rebase onto `dev` and will continue to fail CI until these violations are resolved upstream.

## Test plan

- [ ] `ruff check modules/ tests/` passes with no errors
- [ ] `mypy modules/` passes with no `attr-defined` errors on `content_lower`
- [ ] Existing test suite passes unchanged