### PR TITLE
fix: use sender_pubkey over sender_id when replying to DMs to prevent…

### DIFF
--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -1442,7 +1442,7 @@ class CommandManager:
             rate_limit_key = self.get_rate_limit_key(message)
             if message.is_dm:
                 return await self.send_dm(
-                    message.sender_id or "", content,
+                    message.sender_pubkey or message.sender_id or "", content,
                     skip_user_rate_limit=skip_user_rate_limit,
                     rate_limit_key=rate_limit_key,
                 )
@@ -1518,7 +1518,7 @@ class CommandManager:
                     await asyncio.sleep(sleep_time)
                 skip = skip_user_rate_limit_first if i == 0 else True
                 success = await self.send_dm(
-                    message.sender_id or "",
+                    message.sender_pubkey or message.sender_id or "",
                     chunk,
                     skip_user_rate_limit=skip,
                     rate_limit_key=rate_limit_key,

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -3081,7 +3081,7 @@ class MessageHandler:
                     rate_limit_key = self.bot.command_manager.get_rate_limit_key(message)
                     if message.is_dm:
                         success = await self.bot.command_manager.send_dm(
-                            message.sender_id, response, command_id, rate_limit_key=rate_limit_key
+                            message.sender_pubkey or message.sender_id, response, command_id, rate_limit_key=rate_limit_key
                         )
                     else:
                         success = await self.bot.command_manager.send_channel_message(
@@ -3126,7 +3126,7 @@ class MessageHandler:
                     rate_limit_key = self.bot.command_manager.get_rate_limit_key(message)
                     if message.is_dm:
                         success = await self.bot.command_manager.send_dm(
-                            message.sender_id, response, command_id, rate_limit_key=rate_limit_key
+                            message.sender_pubkey or message.sender_id, response, command_id, rate_limit_key=rate_limit_key
                         )
                     else:
                         success = await self.bot.command_manager.send_channel_message(

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -434,6 +434,49 @@ class TestSendDMRecipientResolution:
         assert "Contact not found for DM recipient identifier" in cm_bot.logger.error.call_args.args[0]
 
     @pytest.mark.asyncio
+    async def test_send_response_dm_uses_sender_pubkey_over_name(self, cm_bot):
+        """send_response for a DM must use sender_pubkey (not sender_id/name) to avoid
+        misrouting when two nodes share a similar display name."""
+        from meshcore import EventType
+
+        cm_bot.connected = True
+        cm_bot.meshcore = Mock()
+        # Name lookup by display name would resolve the WRONG node (same name prefix)
+        cm_bot.meshcore.get_contact_by_name = Mock(return_value=None)
+        cm_bot.meshcore.contacts = {
+            "contact1": {
+                "name": "Alice",
+                "adv_name": "Alice",
+                "public_key": "aabbccddeeff001122",
+            },
+            "contact2": {
+                "name": "Alice-repeater",
+                "adv_name": "Alice-repeater",
+                "public_key": "ffeeddccbbaa998877",
+            },
+        }
+        cm_bot.meshcore.commands = Mock(spec=["send_msg"])
+        cm_bot.meshcore.commands.send_msg = AsyncMock(return_value=Mock(type=EventType.MSG_SENT, payload=None))
+        cm_bot.bot_tx_rate_limiter.wait_for_tx = AsyncMock(return_value=None)
+        manager = make_manager(cm_bot)
+
+        # Message with sender_id=display name but sender_pubkey=unique full pubkey
+        msg = MeshMessage(
+            content="hello",
+            sender_id="Alice",
+            sender_pubkey="aabbccddeeff001122",
+            is_dm=True,
+        )
+
+        result = await manager.send_response(msg, "Hi back")
+
+        assert result is True
+        # send_dm must have been called with the pubkey, not the name
+        cm_bot.meshcore.get_contact_by_name.assert_called_once_with("aabbccddeeff001122")
+        sent_contact = cm_bot.meshcore.commands.send_msg.await_args.args[0]
+        assert sent_contact["public_key"] == "aabbccddeeff001122"
+
+    @pytest.mark.asyncio
     async def test_failed_send_does_not_invoke_listeners(self, cm_bot):
         """When send_channel_message fails (e.g. channel not found), listeners are not called."""
         cm_bot.connected = True

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1824,7 +1824,8 @@ class TestProcessMessageDmKeywordRouting:
 
     @pytest.mark.asyncio
     async def test_keyword_reply_uses_prefix_sender_id_for_dm_send(self, handler):
-        """DM keyword flow should route reply using prefix sender identity."""
+        """DM keyword flow should route reply using pubkey (not display name) to avoid
+        misrouting when two contacts share a similar name."""
         handler.should_process_message = Mock(return_value=True)
         handler.bot.command_manager.check_keywords = Mock(return_value=[("test", "ack")])
         handler.bot.command_manager.match_randomline = Mock(return_value=None)
@@ -1844,7 +1845,8 @@ class TestProcessMessageDmKeywordRouting:
 
         handler.bot.command_manager.send_dm.assert_awaited_once()
         args, kwargs = handler.bot.command_manager.send_dm.await_args
-        assert args[0] == "ab12"
+        # Must use the pubkey (unique) rather than the display name to avoid misrouting
+        assert args[0] == "ab12deadbeefcafebabe"
         assert args[1] == "ack"
         assert args[2].startswith("keyword_test_ab12_")
         assert kwargs["rate_limit_key"] == "ab12deadbeef"


### PR DESCRIPTION
We had some local users who did not received answer to bot DM. We discover that their node names somehow lead to a conflict in bot DM answer (wrong lookup, the bot respond to the "similar" nickname). I propose to use the pubkey instead for answering to DM, much safer and works well here.

Also thanks for the great job !