### PR TITLE
chore(base_service): strip underscores in service name

### DIFF
--- a/modules/service_plugins/base_service.py
+++ b/modules/service_plugins/base_service.py
@@ -234,7 +234,8 @@ class BaseServicePlugin(ABC):
         """
         class_name = self.__class__.__name__
         if class_name.endswith('Service'):
-            return class_name[:-7].lower()  # Remove 'Service' suffix and lowercase
+            # Remove 'Service' suffix and lowercase
+            return class_name[:-7].lower().strip('_')
         return class_name.lower()
 
     def _derive_config_section(self) -> str:


### PR DESCRIPTION
Some services are named `<foo>_Service`, whereby currently only the Service part is stripped. By that, the service name is derived to be `<foo>_`, instead of `<foo>`.

We fix this by stripping all leading and trailing underscores in the service name.