### PR TITLE
v0.9.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
             -not -path "./node_modules/*" \
             -not -path "./.venv/*" \
             -not -path "./venv/*" \
+            -not -path "./dist/*" \
             -print0 | xargs -0 shellcheck --severity=warning
 
   lint:

--- a/TESTING.md
+++ b/TESTING.md
@@ -219,7 +219,8 @@ Tests `modules.scheduler` — `MessageScheduler` pure logic (no threading/asynci
 
 | Class                                 | What it covers                                        |
 |---------------------------------------|-------------------------------------------------------|
-| `TestIsValidTimeFormat`               | Valid HHMM times, invalid hours/minutes/length/chars  |
+| `TestParseScheduleKey`                | 5-field cron, `@daily` preset, legacy HHMM, invalid expr |
+| `TestIsValidTimeFormat`               | Deprecated legacy HHMM validation (invalid h/m/len)   |
 | `TestGetCurrentTime`                  | Valid timezone, invalid fallback, empty timezone      |
 | `TestHasMeshInfoPlaceholders`         | Detects `{total_contacts}`, `{repeaters}`; false case |
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -876,6 +876,18 @@ require_path_bytes_failure_response =
 # false: Only respond to "path", "decode", or "route" keywords
 enable_p_shortcut = true
 
+# Optional first line prepended to path command RF replies (Python str.format on the triggering message).
+# Placeholders match Multitest/Keywords-style responses: {sender}, {connection_info}, {path},
+# {timestamp}, {snr}, {rssi}. Only the first RF chunk includes the prefix when the reply is split.
+# Example: @[{sender}]
+reply_prefix =
+
+# Bytes per hop required before resolving repeater names from the database.
+# 0 or 1: always resolve names (default). 2: require 2-byte (or wider) hops. 3: require 3-byte hops.
+# If the packet path is shorter, the bot still responds with Path: … (hex) plus a short tip (no lookup).
+# Independent of require_path_bytes_greater_or_equal_to above, which can reject the command entirely.
+minimum_path_bytes = 0
+
 # Path Selection Preset
 # Choose a preset that configures multiple related settings:
 # - balanced: Balanced approach using both graph evidence and geographic proximity (default)

--- a/config.ini.example
+++ b/config.ini.example
@@ -428,10 +428,16 @@ category.funfact = fun
 #category.fortune = fun
 
 [Scheduled_Messages]
-# Scheduled message format: HHMM = channel:message
-# Time format: HHMM (24-hour, no colon)
-# Bot will send these messages at the specified times daily
-# Example: 0800 = general:Good morning! Weather update coming soon.
+# Scheduled message format: <schedule> = channel:message
+#
+# <schedule> is one of:
+#   - 5-field crontab (minute hour day-of-month month day-of-week), e.g.
+#       0 8 * * *     = every day at 08:00 (in [Bot] timezone)
+#       30 12 * * 1   = every Monday at 12:30
+#   - Preset aliases (same semantics as common cron @macros):
+#       @yearly @annually  @monthly  @weekly  @daily  @midnight  @hourly
+#   - Deprecated (still accepted, logs a warning): HHMM = daily at that 24h clock time
+#       0800          = same as 0 8 * * *   — migrate to cron; HHMM will be removed later.
 #
 # Newlines: use \n in the message for a line break (e.g. general:Line one\nLine two).
 # Literal backslash: use \\n for backslash+n; \\t for tab.
@@ -465,14 +471,15 @@ category.funfact = fun
 # {repeaters} - Same as {total_repeaters}
 # {companions} - Same as {total_companions}
 # 
-# Example with placeholders:
-# 0800 = Public:Good morning! Network: {total_contacts} total ({total_repeaters} repeaters, {total_companions} companions). {new_repeaters_7d} new repeaters, {new_companions_7d} new companions in last 7d. {recent_activity_24h} active in 24h.
+# Example with placeholders (cron):
+# 0 8 * * * = Public:Good morning! Network: {total_contacts} total ({total_repeaters} repeaters, {total_companions} companions). {new_repeaters_7d} new repeaters, {new_companions_7d} new companions in last 7d. {recent_activity_24h} active in 24h.
 # Example with 30-day active devices and new devices in 7d:
-# 0900 = Public:{total_contacts_30d} active in last 30d: ({total_repeaters_30d} repeaters, {total_companions_30d} companions). {new_repeaters_7d} new repeaters, {new_companions_7d} new companions in last 7d. {recent_activity_24h} users active in last 24h.
+# 0 9 * * * = Public:{total_contacts_30d} active in last 30d: ({total_repeaters_30d} repeaters, {total_companions_30d} companions). {new_repeaters_7d} new repeaters, {new_companions_7d} new companions in last 7d. {recent_activity_24h} users active in last 24h.
 
-#0800 = Public:Good morning! Bot is online and ready.
-#1200 = Public:Midday status check - all systems operational.
-#1800 = Public:Evening update - bot status: Good
+#0 8 * * * = Public:Good morning! Bot is online and ready.
+#0 12 * * * = Public:Midday status check - all systems operational.
+#0 18 * * * = Public:Evening update - bot status: Good
+# @hourly = Public:Hourly ping (preset example; comment out if unused)
 
 [Schedule_Command]
 # Show scheduled messages and advert interval via the 'schedule' command

--- a/config.ini.example
+++ b/config.ini.example
@@ -115,6 +115,12 @@ passive_mode = false
 # Prevents spam by limiting how often the bot can send messages
 rate_limit_seconds = 10
 
+# Spread [Scheduled_Messages] jobs that fire at the same wall time over [0, N) seconds
+# (deterministic from the cron key) so they still air cleanly under bot_tx_rate_limit.
+# Set to 0 to disable stagger only. Scheduled sends skip global rate_limit_seconds;
+# per-channel limits and bot_tx_rate_limit_seconds still apply.
+scheduled_message_max_stagger_seconds = 1.5
+
 # Bot transmission rate limit in seconds between bot messages
 # Prevents bot from overwhelming the mesh network
 bot_tx_rate_limit_seconds = 1.0

--- a/config.ini.example
+++ b/config.ini.example
@@ -434,7 +434,13 @@ category.funfact = fun
 #category.fortune = fun
 
 [Scheduled_Messages]
-# Scheduled message format: <schedule> = channel:message
+# Scheduled message format:
+#   <schedule> = channel:message
+#   <schedule> = channel:#flood_scope:message   (regional flood — middle field must start with #)
+# The scoped form uses split(':', 2): the message body may contain additional colons.
+# Examples:
+#   0 18 * * * = Public:Hello! ...
+#   0 18 * * * = Public:#sea:Hello! ...   (same channel text, sent with #sea flood scope)
 #
 # <schedule> is one of:
 #   - 5-field crontab (minute hour day-of-month month day-of-week), e.g.

--- a/config.ini.example
+++ b/config.ini.example
@@ -1605,6 +1605,9 @@ mqtt1_topic_packets = meshcore/{IATA}/{PUBLIC_KEY}/packets
 mqtt1_websocket_path = /mqtt
 mqtt1_client_id = 
 mqtt1_upload_packet_types = 
+# Optional per-broker JWT (inherit globals if omitted):
+# mqtt1_jwt_ttl_seconds = 3600           # JWT exp claim: iat + this many seconds
+# mqtt1_jwt_renewal_interval = 1800      # Refresh password this often; use < ttl; 0 = no renewal loop
 
 # MQTT Broker 2 - Let's Mesh Analyzer (EU)
 mqtt2_enabled = true
@@ -1627,7 +1630,12 @@ stats_in_status_enabled = true
 # Stats refresh interval (seconds)
 stats_refresh_interval = 300
 
-# JWT renewal interval (seconds, 0 = disabled)
+# JWT TTL in seconds: exp − iat in the MQTT auth token (default 86400 = 24 hours)
+jwt_ttl_seconds = 86400
+
+# JWT renewal interval (seconds): default cadence for proactive token refresh per broker.
+# 0 here makes the default broker renewal interval 0 (no renewal task unless a broker sets mqttN_jwt_renewal_interval > 0).
+# Tokens are still created at MQTT connect and on reconnect.
 jwt_renewal_interval = 86400
 
 # Health check interval (seconds, 0 = disabled)

--- a/config.ini.example
+++ b/config.ini.example
@@ -1372,6 +1372,13 @@ enabled = true
 require_path_bytes_greater_or_equal_to = 0
 # Optional response when rejected by path-byte requirement; leave empty for silent reject
 require_path_bytes_failure_response =
+
+# Optional: full ack template for test/t. When set, overrides [Keywords] test for this command only.
+# Same placeholders as Keywords (sender, phrase, phrase_part, connection_info, path, hops, hops_label,
+# timestamp, elapsed, snr, path_distance, firstlast_distance).
+# Pipe filters (feed-style), e.g. only show cumulative path distance when hops are multibyte (2+ bytes per hop):
+# response_format = ack @[{sender}]{phrase_part} | {connection_info}{path_distance|pathbytes_min:2|prefix_if_nonempty: | Path Dist: }| F/L Dist: {firstlast_distance} | {elapsed} | Rec: {timestamp}
+# Filters: pathbytes_min:N (alias pathbytes:N) clears the field unless bytes_per_hop >= N; prefix_if_nonempty:L prepends literal L when value non-empty after prior filters. If L contains |, put prefix_if_nonempty last in that placeholder (it consumes the rest of the chain as its literal).
 # channels =
 
 [Trace_Command]

--- a/config.ini.example
+++ b/config.ini.example
@@ -1677,6 +1677,10 @@ verbose = false
 # Enable weather service for scheduled forecasts and alert monitoring (true/false)
 enabled = false
 
+# Optional regional TC_FLOOD scope for mesh channel posts from this service.
+# Omit to use [Channels] outgoing_flood_scope_override, or global flood if neither is set.
+# flood_scope = #west
+
 # Daily weather forecast time
 # Format: HH:MM (24-hour format, e.g., "6:00" for 6 AM)
 # Or use "sunrise" or "sunset" for dynamic times based on your location
@@ -1764,6 +1768,9 @@ enabled = false
 # Polls USGS Earthquake API and posts alerts to a channel when quakes occur in the configured region
 enabled = false
 
+# Optional regional TC_FLOOD scope for mesh channel posts from this service.
+# flood_scope = #west
+
 # Channel to post earthquake alerts to
 channel = #general
 
@@ -1838,6 +1845,12 @@ port = 8765
 # Channel message:
 #   {"channel": "general", "message": "Hello from webhook!"}
 #
+# Optional per-request regional scope (overrides [Webhook] flood_scope below):
+#   {"channel": "general", "message": "Hello", "flood_scope": "#west"}
+#
+# Optional default regional scope for all webhook channel posts:
+# flood_scope = #west
+#
 # Direct message:
 #   {"dm_to": "SomeUser", "message": "Private message"}
 #
@@ -1849,6 +1862,9 @@ port = 8765
 # Watches NEW_CONTACT events; after the repeater is stored + geolocated in the database,
 # posts a message when a newly heard repeater shares a prefix with an existing repeater.
 enabled = false
+
+# Optional regional TC_FLOOD scope for mesh channel posts from this service.
+# flood_scope = #west
 
 # Channels to post alerts to (comma-separated).
 # Prefer this option if you want multiple channels.
@@ -1974,8 +1990,11 @@ enabled = false
 [DARC_MoWaS_Service]
 # Enable DARC MoWaS (Mobile Warning System) integration for receiving and posting warnings
 # For legal requirements and backend configuration, please read https://www.darc.de/index.php?id=58435 before operating.
-# Please also ensure to limit the scope of the messages to the revelant region (via Channels.flood_scope).
+# Limit mesh reach via flood_scope here or [Channels] outgoing_flood_scope_override / flood_scopes.
 enabled = false
+
+# Optional regional TC_FLOOD scope for mesh channel posts from this service.
+# flood_scope = #west
 
 # Listen address and port of webserver that receives the webhook POSTs from DARC MoWaS.
 # Must be accessible from the internet (or HAMNET) for MoWaS to reach it.

--- a/config.ini.minimal-example
+++ b/config.ini.minimal-example
@@ -308,6 +308,8 @@ enabled = true
 # true: Test command is available (responds to 'test' or 't')
 # false: Test command is disabled
 enabled = true
+# Optional: overrides [Keywords] test; supports {field|pathbytes_min:2|prefix_if_nonempty: | Path Dist: } style filters (see config.ini.example [Test_Command])
+# response_format =
 
 [Path_Command]
 # Enable or disable the path command

--- a/config.ini.minimal-example
+++ b/config.ini.minimal-example
@@ -320,6 +320,12 @@ enabled = true
 # false: Only respond to "path", "decode", or "route" keywords (default)
 enable_p_shortcut = true
 
+# Optional prefix on path replies: {sender}, {connection_info}, {path}, {timestamp}, {snr}, {rssi}
+# reply_prefix = @[{sender}]
+
+# Bytes per hop before DB repeater lookup (0/1 = off; 2 or 3 = gate weak paths to hex-only + tip)
+# minimum_path_bytes = 0
+
 # Geographic proximity calculation method
 # simple: Use proximity to bot location (default)
 # path: Use proximity to previous/next nodes in the path for more realistic routing

--- a/config.ini.quickstart
+++ b/config.ini.quickstart
@@ -63,6 +63,10 @@ default_country = US
 # Path command - "p" shortcut for quick path decoding
 [Path_Command]
 enable_p_shortcut = true
+# Optional reply prefix (same placeholders as Keywords: sender, connection_info, path, timestamp, snr, rssi)
+# reply_prefix = @[{sender}]
+# Require 2+ or 3 bytes per hop before naming repeaters; else hex + tip only (0/1 = always name)
+# minimum_path_bytes = 0
 
 [Version_Command]
 enabled = true

--- a/config.ini.quickstart
+++ b/config.ini.quickstart
@@ -46,6 +46,7 @@ admin_commands = repeater,webviewer,reload,channelpause
 
 [Keywords]
 test = "ack @[{sender}]{phrase_part} | {connection_info} | Received at: {timestamp}"
+# Optional: set [Test_Command] response_format to override this for test/t (see config.ini.example).
 ping = "Pong!"
 pong = "Ping!"
 help = "Bot Help: test (or t), ping, version, help, hello, cmd, advert, wx, aqi, sun, moon, solar, hfcond, satpass, prefix, path, sports, dice, roll, stats | More: 'help <command>'"

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1020,7 +1020,7 @@ View configured scheduled messages and advert interval.
 schedule
 ```
 
-**Response:** Lists upcoming scheduled posts and current advert timing.
+**Response:** Lists configured scheduled posts (each line shows the cron or preset schedule, or legacy `HH:MM` if you still use deprecated HHMM keys) plus current advert timing.
 
 **Note:** DM-only command by default.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ Many commands and features have their own section. Options there control whether
 Examples of sections that configure specific commands or features:
 
 - **`[Path_Command]`** – Path decoding and repeater selection. See [Path Command](path-command-config.md) for all options.
+- **`[Test_Command]`** – `test` / `t` behavior. Optional **`response_format`** overrides the legacy **`[Keywords] test`** string. Templates support the same placeholders as Keywords, plus **feed-style pipe filters** on placeholders (e.g. `{path_distance|pathbytes_min:2}`) implemented in `modules/response_template.py`—see comments under `[Test_Command]` in `config.ini.example`.
 - **`[Prefix_Command]`** – Prefix lookup, prefix best, range limits.
 - **`[Cmd_Command]`** – `cmd` behavior. Set `cmd_reference_url` to return `Full command reference: <url>` instead of the generated compact command list.
 - **`[Weather]`** – Used by the `wx` / `gwx` commands and the Weather Service plugin (see [Weather Service](weather-service.md)).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,3 +146,7 @@ Some configuration can be reloaded without restarting the bot using the **`reloa
 ## Pausing channel responses (remote)
 
 Admins can DM **`channelpause`** or **`channelresume`** (see `[Admin_ACL]` in `config.ini`) to stop or resume bot reactions on **public channels** only—greeter, keywords, and commands on channels are skipped; DMs still work. The setting is **in memory only** (back to responding on channels after restart). Scheduled channel posts from the scheduler are **not** blocked by this toggle.
+
+## Scheduled messages (`[Scheduled_Messages]`)
+
+Each entry is `<schedule_key> = <value>` where the value is normally **`channel:message`** (first colon separates channel from body). For **regional flood scope** on that send only, use **`channel:#scope:message`**: the middle segment must start with `#` (same convention as `flood_scopes` / `outgoing_flood_scope_override`). The message body may contain more colons. Omit the middle field for classic global flood. See `config.ini.example` under `[Scheduled_Messages]` for examples. The **`schedule`** command lists each job with `(#scope)` when set.

--- a/docs/packet-capture.md
+++ b/docs/packet-capture.md
@@ -129,12 +129,25 @@ Placeholders:
 - `{PUBLIC_KEY}` - Device public key (uppercase)
 - `{public_key}` - Device public key (lowercase)
 
-### Status Publishing
+### Status Publishing and MQTT auth (JWT)
+
+Two separate settings:
+
+- **`jwt_ttl_seconds`** (global) / **`mqttN_jwt_ttl_seconds`** (per broker): lifetime of the JWT in the `exp` claim (`exp = iat + ttl`). Use this when the broker enforces a maximum token lifetime (e.g. 60 minutes → `3600`).
+- **`jwt_renewal_interval`** (global) / **`mqttN_jwt_renewal_interval`** (per broker): how often the bot refreshes the MQTT password for that broker. Set **less than** the TTL (e.g. TTL 3600s and renewal every 1800s) so the connection does not outlive the token.
+
+Per-broker keys override the global values for that broker only. Omit them to inherit globals.
 
 ```ini
 stats_in_status_enabled = true    # Include device stats in status
 stats_refresh_interval = 300      # Publish status every 5 minutes
-jwt_renewal_interval = 86400      # Renew JWT every 24 hours
+
+jwt_ttl_seconds = 86400           # Default JWT exp − iat (24 hours) for all brokers unless overridden
+jwt_renewal_interval = 43200      # Default proactive refresh cadence (12 hours); 0 = no renewal task
+
+# Example on a broker that requires 60-minute tokens and refresh halfway through:
+# mqtt1_jwt_ttl_seconds = 3600
+# mqtt1_jwt_renewal_interval = 1800
 ```
 
 ---

--- a/docs/path-command-config.md
+++ b/docs/path-command-config.md
@@ -11,6 +11,21 @@ The path command supports **1-, 2-, and 3-byte-per-hop** paths (2, 4, or 6 hex c
   - **Comma-separated** (e.g. `path 0102,5f7e`): Hop size is inferred from token length. All tokens must be the same length (2, 4, or 6 hex chars). Example: `0102,5f7e` → two 2-byte hops.
   - **Continuous hex** (e.g. `path 01025f7e`): The bot’s [Bot] **`prefix_bytes`** is used (2 hex chars = 1 byte, 4 = 2 bytes, 6 = 3 bytes). Use comma-separated input to force a multi-byte interpretation when the bot is in 1-byte mode.
 
+## Reply prefix and repeater name gating
+
+These options only affect the **path** command’s reply text and whether repeater names are resolved from the database.
+
+**`reply_prefix`** (string, default empty)
+
+- Prepended as the first line of path command RF replies (only the **first** chunk when the reply is split for length).
+- Uses Python `str.format` on the **triggering** message. Placeholders: `{sender}`, `{connection_info}`, `{path}`, `{timestamp}`, `{snr}`, `{rssi}` (same idea as `[Multitest_Command]` `response_format`).
+
+**`minimum_path_bytes`** (integer `0`–`3`, default `0`)
+
+- **`0` or `1`**: Always resolve repeater names when decoding a path (legacy behavior).
+- **`2` or `3`**: Resolve names only when the packet path uses at least that many **bytes per hop** (from routing metadata or inferred from comma-separated hex width). Otherwise the bot replies with `Path: …` (hex) and a short tip, without a DB lookup.
+- **Not** the same as `require_path_bytes_greater_or_equal_to`: that setting can block the path command entirely; `minimum_path_bytes` only gates naming.
+
 ## Quick Start: Presets
 
 The Path Command supports three presets that configure multiple related settings:

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -5,10 +5,10 @@ Handles all bot commands, keyword matching, and response generation
 """
 
 import asyncio
-from datetime import datetime
 import random
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from hashlib import sha256
 from typing import Any
 

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -5,6 +5,7 @@ Handles all bot commands, keyword matching, and response generation
 """
 
 import asyncio
+from datetime import datetime
 import random
 import time
 from dataclasses import dataclass
@@ -1061,6 +1062,7 @@ class CommandManager:
         skip_user_rate_limit: bool = False,
         rate_limit_key: str | None = None,
         scope: str | None = None,
+        timestamp: datetime | None = None,
     ) -> bool:
         """Send a channel message using meshcore_py (optional flood scope).
 
@@ -1133,7 +1135,10 @@ class CommandManager:
             _max_retries = 2
             for _attempt in range(_max_retries + 1):
                 try:
-                    result = await self.bot.meshcore.commands.send_chan_msg(channel_num, content)
+                    result = await self.bot.meshcore.commands.send_chan_msg(
+                        channel_num, content,
+                        timestamp=int(timestamp.timestamp()) if timestamp else None,
+                    )
                 finally:
                     if not scope_is_global and hasattr(self.bot.meshcore.commands, "set_flood_scope"):
                         await self.bot.meshcore.commands.set_flood_scope("*")

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -121,6 +121,23 @@ class CommandManager:
 
         self.logger.info(f"CommandManager initialized with {len(self.commands)} plugins")
 
+    def _flood_scopes_config_raw(self) -> str:
+        """Raw flood_scopes value; [Channels] is canonical, [Bot] accepted with a warning."""
+        for section in ("Channels", "Bot"):
+            if self.bot.config.has_section(section) and self.bot.config.has_option(
+                section, "flood_scopes"
+            ):
+                raw = (self.bot.config.get(section, "flood_scopes") or "").strip()
+                if not raw:
+                    continue
+                if section != "Channels":
+                    self.logger.warning(
+                        "flood_scopes is set in [Bot]; move it to [Channels] "
+                        "(still loaded for this run)"
+                    )
+                return raw
+        return ""
+
     def _load_flood_scope_keys(self) -> dict[str, bytes]:
         """Load flood_scopes config into a name→16-byte-key dict for HMAC matching.
 
@@ -129,10 +146,9 @@ class CommandManager:
         FLOOD messages are still permitted through the allowlist check.
         """
         scope_keys: dict[str, bytes] = {}
-        if not (self.bot.config.has_section("Channels") and
-                self.bot.config.has_option("Channels", "flood_scopes")):
+        raw = self._flood_scopes_config_raw()
+        if not raw:
             return scope_keys
-        raw = (self.bot.config.get("Channels", "flood_scopes") or "").strip()
         for entry in (s.strip() for s in raw.split(",") if s.strip()):
             normalized = self._normalize_scope_name(entry)
             if normalized in ("", "*", "0", "None"):
@@ -154,6 +170,37 @@ class CommandManager:
         if not scope.startswith("#"):
             return "#" + scope
         return scope
+
+    def _outgoing_flood_scope_override(self) -> str:
+        """[Channels] outgoing_flood_scope_override when set, else empty string."""
+        if self.bot.config.has_section("Channels") and self.bot.config.has_option(
+            "Channels", "outgoing_flood_scope_override"
+        ):
+            return (self.bot.config.get("Channels", "outgoing_flood_scope_override") or "").strip()
+        return ""
+
+    def resolve_channel_send_scope(
+        self,
+        *,
+        scope: str | None = None,
+        message: MeshMessage | None = None,
+        config_section: str | None = None,
+    ) -> str | None:
+        """Resolve explicit regional scope before send_channel_message applies override.
+
+        Precedence: explicit ``scope`` arg → ``message.reply_scope`` (mirror incoming) →
+        ``flood_scope`` in ``config_section``. Returns ``None`` when unset so
+        ``send_channel_message`` falls back to ``outgoing_flood_scope_override``.
+        """
+        if scope is not None:
+            return scope
+        if message is not None and message.reply_scope is not None:
+            return message.reply_scope
+        if config_section and self.bot.config.has_section(config_section):
+            raw = (self.bot.config.get(config_section, "flood_scope", fallback="") or "").strip()
+            if raw:
+                return self._normalize_scope_name(raw)
+        return None
 
     def _should_queue_command(self, command: BaseCommand, message: MeshMessage) -> tuple[bool, float]:
         """Check if command should be queued instead of rejected.
@@ -1120,13 +1167,17 @@ class CommandManager:
                 # Don't fail the send if transmission tracking fails
 
             # Optional flood scope (region): set before send, restore after
-            scope_cfg = ""
-            if self.bot.config.has_section("Channels") and self.bot.config.has_option("Channels", "outgoing_flood_scope_override"):
-                scope_cfg = (self.bot.config.get("Channels", "outgoing_flood_scope_override") or "").strip()
-            scope_to_use = (scope if scope is not None else scope_cfg) or ""
+            resolved = self.resolve_channel_send_scope(scope=scope)
+            scope_to_use = (
+                resolved if resolved is not None else self._outgoing_flood_scope_override()
+            ) or ""
             scope_is_global = scope_to_use in ("", "*", "0", "None")
             if not scope_is_global:
                 scope_to_use = self._normalize_scope_name(scope_to_use)
+            if scope_is_global:
+                self.logger.debug("Outbound channel flood scope: global (no set_flood_scope)")
+            else:
+                self.logger.debug("Outbound channel flood scope: %s (set_flood_scope)", scope_to_use)
             if not scope_is_global and hasattr(self.bot.meshcore.commands, "set_flood_scope"):
                 await self.bot.meshcore.commands.set_flood_scope(scope_to_use)
 

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -1455,7 +1455,7 @@ class CommandManager:
             rate_limit_key = self.get_rate_limit_key(message)
             if message.is_dm:
                 return await self.send_dm(
-                    message.sender_id or "",
+                    message.sender_pubkey or message.sender_id or "",
                     content,
                     command_id,
                     skip_user_rate_limit=skip_user_rate_limit,
@@ -1535,7 +1535,7 @@ class CommandManager:
                     await asyncio.sleep(sleep_time)
                 skip = skip_user_rate_limit_first if i == 0 else True
                 success = await self.send_dm(
-                    message.sender_id or "",
+                    message.sender_pubkey or message.sender_id or "",
                     chunk,
                     skip_user_rate_limit=skip,
                     rate_limit_key=rate_limit_key,

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -1418,7 +1418,14 @@ class CommandManager:
 
         return commands_list
 
-    async def send_response(self, message: MeshMessage, content: str, skip_user_rate_limit: bool = False) -> bool:
+    async def send_response(
+        self,
+        message: MeshMessage,
+        content: str,
+        skip_user_rate_limit: bool = False,
+        *,
+        command_id: str | None = None,
+    ) -> bool:
         """Unified method for sending responses to users.
 
         Automatically determines whether to send a DM or channel message based
@@ -1428,6 +1435,7 @@ class CommandManager:
             message: The original message being responded to.
             content: The response content.
             skip_user_rate_limit: If True, skip the user rate limiter check (for automated responses).
+            command_id: Optional id for repeat/transmission tracking (e.g. keyword or RandomLine flows).
 
         Returns:
             bool: True if response was sent successfully, False otherwise.
@@ -1442,13 +1450,17 @@ class CommandManager:
             rate_limit_key = self.get_rate_limit_key(message)
             if message.is_dm:
                 return await self.send_dm(
-                    message.sender_id or "", content,
+                    message.sender_id or "",
+                    content,
+                    command_id,
                     skip_user_rate_limit=skip_user_rate_limit,
                     rate_limit_key=rate_limit_key,
                 )
             else:
                 return await self.send_channel_message(
-                    message.channel or "", content,
+                    message.channel or "",
+                    content,
+                    command_id,
                     skip_user_rate_limit=skip_user_rate_limit,
                     rate_limit_key=rate_limit_key,
                     scope=getattr(message, 'reply_scope', None),

--- a/modules/commands/announcements_command.py
+++ b/modules/commands/announcements_command.py
@@ -347,8 +347,12 @@ class AnnouncementsCommand(BaseCommand):
             # Determine channel
             target_channel = channel_name if channel_name else self.default_channel
 
-            # Send announcement to channel
-            success = await self.bot.command_manager.send_channel_message(target_channel, announcement_text)
+            # Send announcement to channel (mirror incoming flood scope like send_response)
+            success = await self.bot.command_manager.send_channel_message(
+                target_channel,
+                announcement_text,
+                scope=getattr(message, "reply_scope", None),
+            )
 
             if success:
                 # Record execution (resets cooldown timer)

--- a/modules/commands/base_command.py
+++ b/modules/commands/base_command.py
@@ -505,20 +505,33 @@ class BaseCommand(ABC):
             'module_name': self.__class__.__module__
         }
 
-    async def send_response(self, message: MeshMessage, content: str, skip_user_rate_limit: bool = False) -> bool:
+    async def send_response(
+        self,
+        message: MeshMessage,
+        content: str,
+        skip_user_rate_limit: bool = False,
+        *,
+        command_id: str | None = None,
+    ) -> bool:
         """Unified method for sending responses to users.
 
         Args:
             message: The message to respond to.
             content: The response content.
             skip_user_rate_limit: If True, skip the user rate limiter check (for automated responses).
+            command_id: Optional id for repeat/transmission tracking.
 
         Returns:
             bool: True if the response was sent successfully, False otherwise.
         """
         try:
             # Use the command manager's send_response method to ensure response capture
-            return await self.bot.command_manager.send_response(message, content, skip_user_rate_limit=skip_user_rate_limit)
+            return await self.bot.command_manager.send_response(
+                message,
+                content,
+                skip_user_rate_limit=skip_user_rate_limit,
+                command_id=command_id,
+            )
         except Exception as e:
             self.logger.error(f"Failed to send response: {e}")
             return False

--- a/modules/commands/path_command.py
+++ b/modules/commands/path_command.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Optional
 
 from ..models import MeshMessage
 from ..security_utils import sanitize_name
-from ..utils import calculate_distance, parse_path_string
+from ..utils import bytes_per_hop_from_routing_and_nodes, calculate_distance, parse_path_string
 from .base_command import BaseCommand
 
 
@@ -182,14 +182,7 @@ class PathCommand(BaseCommand):
         self, node_ids: list[str], routing_info: Optional[dict[str, Any]]
     ) -> int:
         """Bytes per hop from packet metadata or inferred from hex node width."""
-        if routing_info:
-            bph = routing_info.get('bytes_per_hop')
-            if isinstance(bph, int) and 1 <= bph <= 3:
-                return bph
-        if not node_ids:
-            return 1
-        widths = [len(n) // 2 for n in node_ids]
-        return min(widths)
+        return bytes_per_hop_from_routing_and_nodes(routing_info, node_ids)
 
     def _should_resolve_repeater_names(
         self, node_ids: list[str], routing_info: Optional[dict[str, Any]]

--- a/modules/commands/path_command.py
+++ b/modules/commands/path_command.py
@@ -139,6 +139,18 @@ class PathCommand(BaseCommand):
             if "p" not in self.keywords:
                 self.keywords.append("p")
 
+        reply_prefix_raw = bot.config.get('Path_Command', 'reply_prefix', fallback='')
+        self.path_reply_prefix = self._strip_quotes_from_config(reply_prefix_raw).strip()
+
+        minimum_path_bytes_raw = bot.config.getint('Path_Command', 'minimum_path_bytes', fallback=0)
+        if minimum_path_bytes_raw not in (0, 1, 2, 3):
+            self.logger.warning(
+                f"Invalid Path_Command.minimum_path_bytes={minimum_path_bytes_raw}; defaulting to 0"
+            )
+            self.minimum_path_bytes = 0
+        else:
+            self.minimum_path_bytes = minimum_path_bytes_raw
+
         try:
             # Try to get location from Bot section
             if bot.config.has_section('Bot'):
@@ -165,6 +177,52 @@ class PathCommand(BaseCommand):
                 self.logger.info("Bot section not found - geographic proximity guessing disabled")
         except Exception as e:
             self.logger.warning(f"Error reading bot location from config: {e} - geographic proximity guessing disabled")
+
+    def _bytes_per_hop_from_nodes_and_routing(
+        self, node_ids: list[str], routing_info: Optional[dict[str, Any]]
+    ) -> int:
+        """Bytes per hop from packet metadata or inferred from hex node width."""
+        if routing_info:
+            bph = routing_info.get('bytes_per_hop')
+            if isinstance(bph, int) and 1 <= bph <= 3:
+                return bph
+        if not node_ids:
+            return 1
+        widths = [len(n) // 2 for n in node_ids]
+        return min(widths)
+
+    def _should_resolve_repeater_names(
+        self, node_ids: list[str], routing_info: Optional[dict[str, Any]]
+    ) -> bool:
+        if self.minimum_path_bytes in (0, 1):
+            return True
+        bph = self._bytes_per_hop_from_nodes_and_routing(node_ids, routing_info)
+        return bph >= self.minimum_path_bytes
+
+    def _format_path_reply_prefix(self, message: MeshMessage) -> str:
+        if not self.path_reply_prefix:
+            return ''
+        formatted = self.format_response(message, self.path_reply_prefix).rstrip()
+        if not formatted:
+            return ''
+        return formatted + '\n'
+
+    def _format_repeater_resolution_deferred(self, node_ids: list[str]) -> str:
+        path_display = ','.join(node_ids)
+        return self.translate(
+            'commands.path.repeater_resolution_deferred',
+            path=path_display,
+            minimum_path_bytes=self.minimum_path_bytes,
+        )
+
+    async def _decode_node_ids(
+        self, node_ids: list[str], routing_info: Optional[dict[str, Any]] = None
+    ) -> str:
+        self.logger.info(f"Decoding path with {len(node_ids)} nodes: {','.join(node_ids)}")
+        if not self._should_resolve_repeater_names(node_ids, routing_info):
+            return self._format_repeater_resolution_deferred(node_ids)
+        repeater_info = await self._lookup_repeater_names(node_ids)
+        return self._format_path_response(node_ids, repeater_info)
 
     def can_execute(self, message: MeshMessage, skip_channel_check: bool = False) -> bool:
         """Check if this command can be executed with the given message.
@@ -219,7 +277,9 @@ class PathCommand(BaseCommand):
         await self._send_path_response(message, response)
         return True
 
-    async def _decode_path(self, path_input: str) -> str:
+    async def _decode_path(
+        self, path_input: str, routing_info: Optional[dict[str, Any]] = None
+    ) -> str:
         """Decode hex path data to repeater names.
         Comma-separated tokens infer hop size (2, 4, or 6 hex chars per node).
         Otherwise uses bot.prefix_hex_chars via parse_path_string().
@@ -249,9 +309,7 @@ class PathCommand(BaseCommand):
             if not node_ids:
                 return self.translate('commands.path.no_valid_hex')
 
-            self.logger.info(f"Decoding path with {len(node_ids)} nodes: {','.join(node_ids)}")
-            repeater_info = await self._lookup_repeater_names(node_ids)
-            return self._format_path_response(node_ids, repeater_info)
+            return await self._decode_node_ids(node_ids, routing_info)
 
         except Exception as e:
             self.logger.error(f"Error decoding path: {e}")
@@ -1663,55 +1721,50 @@ class PathCommand(BaseCommand):
 
     async def _send_path_response(self, message: MeshMessage, response: str):
         """Send path response, splitting into multiple messages if necessary"""
-        # Store the complete response for web viewer integration BEFORE splitting
-        # command_manager will prioritize command.last_response over _last_response
-        # This ensures capture_command gets the full response, not just the last split message
-        self.last_response = response
+        prefix = self._format_path_reply_prefix(message)
+        self.last_response = prefix + response if prefix else response
 
-        # Get dynamic max message length based on message type and bot username
         max_length = self.get_max_message_length(message)
+        prefix_len = self._count_byte_length(prefix)
+        first_segment_max = max_length - prefix_len
+        if first_segment_max < 1:
+            first_segment_max = 1
 
-        if self._count_byte_length(response) <= max_length:
-            # Single message is fine
-            await self.send_response(message, response)
-        else:
-            # Split into multiple messages for over-the-air transmission
-            # But keep the full response in last_response for web viewer
-            lines = response.split('\n')
-            current_message = ""
-            message_count = 0
+        if self._count_byte_length(response) + prefix_len <= max_length:
+            await self.send_response(message, prefix + response)
+            return
 
-            for i, line in enumerate(lines):
-                # Check if adding this line would exceed max_length display width
-                if self._count_byte_length(current_message) + self._count_byte_length(line) + 1 > max_length:  # +1 for newline
-                    # Send current message and start new one
-                    if current_message:
-                        # Add ellipsis on new line to end of continued message (if not the last message)
-                        if i < len(lines):
-                            current_message += self.translate('commands.path.continuation_end')
-                        # Per-user rate limit applies only to first message (trigger); skip for continuations
-                        await self.send_response(
-                            message, current_message.rstrip(),
-                            skip_user_rate_limit=(message_count > 0)
-                        )
-                        await asyncio.sleep(3.0)  # Delay between messages (same as other commands)
-                        message_count += 1
+        lines = response.split('\n')
+        current_message = ""
+        message_count = 0
 
-                    # Start new message with ellipsis on new line at beginning (if not first message)
-                    if message_count > 0:
-                        current_message = self.translate('commands.path.continuation_start', line=line)
-                    else:
-                        current_message = line
+        for i, line in enumerate(lines):
+            body_budget = first_segment_max if message_count == 0 else max_length
+            if self._count_byte_length(current_message) + self._count_byte_length(line) + 1 > body_budget:
+                if current_message:
+                    if i < len(lines):
+                        current_message += self.translate('commands.path.continuation_end')
+                    out = (prefix + current_message.rstrip()) if message_count == 0 else current_message.rstrip()
+                    await self.send_response(
+                        message, out,
+                        skip_user_rate_limit=(message_count > 0)
+                    )
+                    await asyncio.sleep(3.0)
+                    message_count += 1
+
+                if message_count > 0:
+                    current_message = self.translate('commands.path.continuation_start', line=line)
                 else:
-                    # Add line to current message
-                    if current_message:
-                        current_message += f"\n{line}"
-                    else:
-                        current_message = line
+                    current_message = line
+            else:
+                if current_message:
+                    current_message += f"\n{line}"
+                else:
+                    current_message = line
 
-            # Send the last message if there's content (continuation; skip per-user rate limit)
-            if current_message:
-                await self.send_response(message, current_message, skip_user_rate_limit=True)
+        if current_message:
+            out = (prefix + current_message.rstrip()) if message_count == 0 else current_message.rstrip()
+            await self.send_response(message, out, skip_user_rate_limit=True)
 
     async def _extract_path_from_recent_messages(self) -> str:
         """Extract path from the current message's path information (same as test command).
@@ -1732,9 +1785,7 @@ class PathCommand(BaseCommand):
                 path_nodes = routing_info.get('path_nodes', [])
                 if path_nodes:
                     node_ids = [n.upper() for n in path_nodes]
-                    self.logger.info(f"Decoding path from routing_info with {len(node_ids)} nodes: {','.join(node_ids)}")
-                    repeater_info = await self._lookup_repeater_names(node_ids)
-                    return self._format_path_response(node_ids, repeater_info)
+                    return await self._decode_node_ids(node_ids, routing_info)
 
             # Fallback: parse message.path string (e.g. no routing_info or legacy path)
             if not msg.path:
@@ -1747,10 +1798,10 @@ class PathCommand(BaseCommand):
             path_part = path_string.split(" via ROUTE_TYPE_")[0] if " via ROUTE_TYPE_" in path_string else path_string
 
             if ',' in path_part:
-                return await self._decode_path(path_part)
+                return await self._decode_path(path_part, routing_info)
             hex_pattern = rf'[0-9a-fA-F]{{{getattr(self.bot, "prefix_hex_chars", 2)}}}'
             if re.search(hex_pattern, path_part):
-                return await self._decode_path(path_part)
+                return await self._decode_path(path_part, routing_info)
             return self.translate('commands.path.path_prefix', path_string=path_string)
 
         except Exception as e:

--- a/modules/commands/schedule_command.py
+++ b/modules/commands/schedule_command.py
@@ -68,10 +68,8 @@ class ScheduleCommand(BaseCommand):
         scheduled = self._get_scheduled_messages()
         if scheduled:
             lines.append(f"Scheduled ({len(scheduled)}):")
-            for time_str, channel, preview in scheduled:
-                # Format HHMM → HH:MM
-                hhmm = f"{time_str[:2]}:{time_str[2:]}"
-                lines.append(f"  {hhmm} #{channel}: {preview}")
+            for sched_display, channel, preview in scheduled:
+                lines.append(f"  {sched_display} #{channel}: {preview}")
         else:
             lines.append("No scheduled messages configured.")
 
@@ -82,22 +80,36 @@ class ScheduleCommand(BaseCommand):
 
         return "\n".join(lines)
 
-    def _get_scheduled_messages(self) -> list[tuple]:
-        """Return sorted list of (time_str, channel, preview) tuples."""
+    def _get_scheduled_messages(self) -> list[tuple[str, str, str]]:
+        """Return sorted list of (schedule_display, channel, preview) tuples."""
         scheduler = getattr(self.bot, "scheduler", None)
         if scheduler is None:
             return []
 
         scheduled = getattr(scheduler, "scheduled_messages", {})
-        results = []
-        for time_str, payload in sorted(scheduled.items()):
-            channel, message = payload
+        rows: list[tuple[str, str, str, str]] = []
+        for schedule_key, payload in scheduled.items():
+            if len(payload) == 3:
+                channel, message, display_label = payload
+            else:
+                channel, message = payload[0], payload[1]
+                sk = schedule_key
+                display_label = (
+                    f"{sk[:2]}:{sk[2:]}"
+                    if len(sk) == 4 and sk.isdigit()
+                    else sk
+                )
             # Truncate long messages so response stays compact
             # Strip control characters that could corrupt the response
-            safe_message = ''.join(c if c.isprintable() or c == ' ' else '?' for c in message)
-            preview = safe_message if len(safe_message) <= 40 else safe_message[:37] + "..."
-            results.append((time_str, channel, preview))
-        return results
+            safe_message = "".join(
+                c if c.isprintable() or c == " " else "?" for c in message
+            )
+            preview = (
+                safe_message if len(safe_message) <= 40 else safe_message[:37] + "..."
+            )
+            rows.append((display_label, schedule_key, channel, preview))
+        rows.sort(key=lambda r: (r[0].lower(), r[1]))
+        return [(r[0], r[2], r[3]) for r in rows]
 
     def _get_advert_info(self) -> Optional[str]:
         """Return a one-line advert interval summary, or None if disabled."""

--- a/modules/commands/schedule_command.py
+++ b/modules/commands/schedule_command.py
@@ -68,8 +68,9 @@ class ScheduleCommand(BaseCommand):
         scheduled = self._get_scheduled_messages()
         if scheduled:
             lines.append(f"Scheduled ({len(scheduled)}):")
-            for sched_display, channel, preview in scheduled:
-                lines.append(f"  {sched_display} #{channel}: {preview}")
+            for sched_display, channel, preview, scope in scheduled:
+                scope_part = f" ({scope})" if scope else ""
+                lines.append(f"  {sched_display} #{channel}{scope_part}: {preview}")
         else:
             lines.append("No scheduled messages configured.")
 
@@ -80,19 +81,28 @@ class ScheduleCommand(BaseCommand):
 
         return "\n".join(lines)
 
-    def _get_scheduled_messages(self) -> list[tuple[str, str, str]]:
-        """Return sorted list of (schedule_display, channel, preview) tuples."""
+    def _get_scheduled_messages(self) -> list[tuple[str, str, str, str | None]]:
+        """Return sorted list of (schedule_display, channel, preview, scope) tuples."""
         scheduler = getattr(self.bot, "scheduler", None)
         if scheduler is None:
             return []
 
         scheduled = getattr(scheduler, "scheduled_messages", {})
-        rows: list[tuple[str, str, str, str]] = []
+        rows: list[tuple[str, str, str, str, str | None]] = []
         for schedule_key, payload in scheduled.items():
-            if len(payload) == 3:
+            if len(payload) >= 4:
+                channel, message, display_label, scope = (
+                    payload[0],
+                    payload[1],
+                    payload[2],
+                    payload[3],
+                )
+            elif len(payload) == 3:
                 channel, message, display_label = payload
+                scope = None
             else:
                 channel, message = payload[0], payload[1]
+                scope = None
                 sk = schedule_key
                 display_label = (
                     f"{sk[:2]}:{sk[2:]}"
@@ -107,9 +117,9 @@ class ScheduleCommand(BaseCommand):
             preview = (
                 safe_message if len(safe_message) <= 40 else safe_message[:37] + "..."
             )
-            rows.append((display_label, schedule_key, channel, preview))
+            rows.append((display_label, schedule_key, channel, preview, scope))
         rows.sort(key=lambda r: (r[0].lower(), r[1]))
-        return [(r[0], r[2], r[3]) for r in rows]
+        return [(r[0], r[2], r[3], r[4]) for r in rows]
 
     def _get_advert_info(self) -> Optional[str]:
         """Return a one-line advert interval summary, or None if disabled."""

--- a/modules/commands/test_command.py
+++ b/modules/commands/test_command.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from ..models import MeshMessage
+from ..response_template import format_piped_template
 from ..utils import calculate_distance, extract_path_node_ids_from_message
 from .base_command import BaseCommand
 
@@ -141,6 +142,12 @@ class TestCommand(BaseCommand):
         Returns:
             Optional[str]: The configured or default response format string.
         """
+        if self.bot.config.has_section('Test_Command'):
+            raw = self.bot.config.get('Test_Command', 'response_format', fallback='')
+            if raw:
+                cleaned = self._strip_quotes_from_config(raw).strip()
+                if cleaned:
+                    return cleaned
         if self.bot.config.has_section('Keywords'):
             format_str = self.bot.config.get('Keywords', 'test', fallback=None)
             if format_str:
@@ -683,19 +690,26 @@ class TestCommand(BaseCommand):
             path_distance = self._calculate_path_distance(message)
             firstlast_distance = self._calculate_firstlast_distance(message)
             phrase_part = f": {phrase}" if phrase else ""
-            return response_format.format(
-                sender=message.sender_id or self.translate('common.unknown_sender'),
-                phrase=phrase,
-                phrase_part=phrase_part,
-                connection_info=connection_info,
-                path=path_display,
-                hops=hops_str,
-                hops_label=hops_label,
-                timestamp=timestamp,
-                elapsed=elapsed,
-                snr=message.snr or self.translate('common.unknown'),
-                path_distance=path_distance or "",
-                firstlast_distance=firstlast_distance or ""
+            fields = {
+                'sender': message.sender_id or self.translate('common.unknown_sender'),
+                'phrase': phrase,
+                'phrase_part': phrase_part,
+                'connection_info': connection_info,
+                'path': path_display,
+                'hops': hops_str,
+                'hops_label': hops_label,
+                'timestamp': timestamp,
+                'elapsed': elapsed,
+                'snr': str(message.snr) if message.snr is not None else self.translate('common.unknown'),
+                'path_distance': path_distance or '',
+                'firstlast_distance': firstlast_distance or '',
+            }
+            return format_piped_template(
+                response_format,
+                fields,
+                message=message,
+                logger=self.logger,
+                prefix_hex_chars=getattr(self.bot, 'prefix_hex_chars', 2),
             )
         except (KeyError, ValueError) as e:
             self.logger.warning(f"Error formatting test response: {e}")

--- a/modules/core.py
+++ b/modules/core.py
@@ -918,6 +918,10 @@ wind_speed_unit = mph
 precipitation_unit = inch
 
 [Path_Command]
+# Optional prefix on path command replies: {sender}, {connection_info}, {path}, {timestamp}, {snr}, {rssi}
+# reply_prefix =
+# Bytes per hop before repeater name lookup (0/1 = always; 2/3 = gate to hex + tip if shorter)
+# minimum_path_bytes = 0
 # Geographic proximity calculation method
 # simple: Use proximity to bot location (default)
 # path: Use proximity to previous/next nodes in the path for more realistic routing

--- a/modules/feed_manager.py
+++ b/modules/feed_manager.py
@@ -96,8 +96,10 @@ class FeedManager:
         # Semaphore to limit concurrent requests
         self._request_semaphore = asyncio.Semaphore(5)
 
-        # Serialize process_message_queue (scheduler may schedule another run if result() times out)
+        # Serialize process_message_queue; lock is checked before acquiring to avoid coroutine pileup
         self._process_queue_lock: Optional[asyncio.Lock] = None
+        # Persisted across runs so per-feed send intervals are respected without sleeping under the lock
+        self._feed_last_send: dict[int, float] = {}
 
         self.logger.info("FeedManager initialized")
 
@@ -1252,6 +1254,8 @@ class FeedManager:
         """Process queued feed messages and send them at configured intervals"""
         if self._process_queue_lock is None:
             self._process_queue_lock = asyncio.Lock()
+        if self._process_queue_lock.locked():
+            return  # previous run still in progress; skip this tick
         async with self._process_queue_lock:
             await self._process_message_queue_inner()
 
@@ -1277,9 +1281,6 @@ class FeedManager:
             if not messages:
                 return
 
-            # Group messages by feed to respect per-feed send intervals
-            feed_last_send: dict[int, float] = {}
-
             for msg in messages:
                 feed_id = msg['feed_id']
                 channel_name = msg['channel_name']
@@ -1291,12 +1292,12 @@ class FeedManager:
                 # Get send interval for this feed (default if not set)
                 send_interval = msg['message_send_interval_seconds'] or self.default_send_interval
 
-                # Check if we need to wait before sending this feed's message
-                if feed_id in feed_last_send:
-                    elapsed = time.time() - feed_last_send[feed_id]
+                # Skip messages whose feed interval hasn't elapsed yet; the next
+                # scheduler tick (2 s) will retry without blocking under the lock.
+                if feed_id in self._feed_last_send:
+                    elapsed = time.time() - self._feed_last_send[feed_id]
                     if elapsed < send_interval:
-                        wait_time = send_interval - elapsed
-                        await asyncio.sleep(wait_time)
+                        continue
 
                 # Send the message
                 try:
@@ -1316,7 +1317,7 @@ class FeedManager:
                         # Record activity
                         self._record_feed_activity(feed_id, item_id, item_title)
                         self.logger.debug(f"Sent queued feed message to {channel_name}: {item_title[:50]}")
-                        feed_last_send[feed_id] = time.time()
+                        self._feed_last_send[feed_id] = time.time()
                     else:
                         self.logger.warning(f"Failed to send queued feed message to channel {channel_name}")
                         self._record_feed_error(feed_id, 'channel', f"Failed to send to channel {channel_name}")

--- a/modules/mesh_graph.py
+++ b/modules/mesh_graph.py
@@ -466,18 +466,24 @@ class MeshGraph:
         if self.write_strategy == 'immediate':
             self._write_edge_to_db(edge_key, is_new_edge)
         elif self.write_strategy == 'batched':
+            flush_needed = False
             with self.pending_lock:
                 self.pending_updates.add(edge_key)
                 if len(self.pending_updates) >= self.batch_max_pending:
-                    self._flush_pending_updates_sync()
+                    flush_needed = True
+            if flush_needed:
+                self._flush_pending_updates_sync()
         elif self.write_strategy == 'hybrid':
             if is_new_edge:
                 self._write_edge_to_db(edge_key, True)
             else:
+                flush_needed = False
                 with self.pending_lock:
                     self.pending_updates.add(edge_key)
                     if len(self.pending_updates) >= self.batch_max_pending:
-                        self._flush_pending_updates_sync()
+                        flush_needed = True
+                if flush_needed:
+                    self._flush_pending_updates_sync()
         self._notify_web_viewer_edge(edge_key, is_new_edge)
 
     def _notify_web_viewer_edge(self, edge_key: tuple[str, str], is_new: bool):

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -98,6 +98,120 @@ class MessageHandler:
                 return name
         return None
 
+    @staticmethod
+    def _scope_fields_from_packet_info(
+        packet_info: dict[str, Any] | None,
+    ) -> tuple[int | None, int | None, int | None, str]:
+        """Extract TC_FLOOD scope-match inputs from decode_meshcore_packet output."""
+        if not packet_info:
+            return None, None, None, ""
+        rt = packet_info.get("route_type")
+        if rt is not None and hasattr(rt, "value"):
+            rt = rt.value
+        pt = packet_info.get("payload_type")
+        if pt is not None and hasattr(pt, "value"):
+            pt = int(pt.value)
+        elif pt is not None:
+            pt = int(pt)
+        tc_code1 = None
+        transport_codes = packet_info.get("transport_codes")
+        if isinstance(transport_codes, dict):
+            tc_code1 = transport_codes.get("code1")
+        payload_hex = (packet_info.get("payload_hex") or "") or ""
+        return rt, tc_code1, pt, payload_hex
+
+    def _resolve_reply_scope_from_rf_data(
+        self,
+        recent_rf_data: dict[str, Any],
+        packet_info: dict[str, Any] | None,
+        scope_keys: dict[str, bytes],
+    ) -> str | None:
+        """Match incoming TC_FLOOD to flood_scopes, preferring decoded packet over stale cache."""
+        rt = recent_rf_data.get("route_type_int")
+        tc_code1 = recent_rf_data.get("transport_code1")
+        scope_payload_type = recent_rf_data.get("payload_type_int")
+        scope_payload_hex = recent_rf_data.get("scope_payload_hex") or ""
+
+        dec_rt, dec_tc, dec_pt, dec_hex = self._scope_fields_from_packet_info(packet_info)
+        used_decode_fallback = False
+        if dec_rt == 0:
+            if rt != 0:
+                used_decode_fallback = True
+            rt = 0
+            if dec_tc is not None:
+                if tc_code1 != dec_tc:
+                    used_decode_fallback = True
+                tc_code1 = dec_tc
+            if dec_pt is not None:
+                if scope_payload_type != dec_pt:
+                    used_decode_fallback = True
+                scope_payload_type = dec_pt
+            if dec_hex:
+                if scope_payload_hex != dec_hex:
+                    used_decode_fallback = True
+                scope_payload_hex = dec_hex
+
+        if used_decode_fallback:
+            self.logger.debug(
+                "TC_FLOOD scope fields from packet decode (cache had route_type=%s tc=%s)",
+                recent_rf_data.get("route_type_int"),
+                recent_rf_data.get("transport_code1"),
+            )
+
+        if not (
+            rt == 0
+            and tc_code1 is not None
+            and scope_payload_type is not None
+            and scope_payload_hex
+        ):
+            if scope_keys:
+                self.logger.debug(
+                    "Scope check: route_type=%s (need 0=TC_FLOOD), "
+                    "tc_code1=%s, payload_type=%s, payload_hex=%s",
+                    rt,
+                    "set" if tc_code1 is not None else "None",
+                    scope_payload_type,
+                    "set" if scope_payload_hex else "empty",
+                )
+            return None
+
+        try:
+            pkt_payload_bytes = bytes.fromhex(scope_payload_hex)
+        except ValueError:
+            self.logger.debug("Scope check: invalid scope_payload_hex on correlated RF data")
+            return None
+
+        reply_scope = self._match_scope(tc_code1, scope_payload_type, pkt_payload_bytes, scope_keys)
+        if reply_scope:
+            self.logger.info(
+                "Incoming TC_FLOOD matched scope '%s' (tc_code1=%s); reply will use same scope",
+                reply_scope,
+                tc_code1,
+            )
+        elif scope_keys:
+            self.logger.debug(
+                "TC_FLOOD scope not matched: tc_code1=%s payload_type=%s "
+                "(configured scopes: %s)",
+                tc_code1,
+                scope_payload_type,
+                ", ".join(sorted(scope_keys.keys())),
+            )
+        return reply_scope
+
+    def _effective_route_type_int(
+        self,
+        recent_rf_data: dict[str, Any] | None,
+        packet_info: dict[str, Any] | None,
+    ) -> int | None:
+        """Route type for allowlist gate, preferring decode when it indicates TC_FLOOD."""
+        if not recent_rf_data:
+            return None
+        rt = recent_rf_data.get("route_type_int")
+        dec_rt, _, _, _ = self._scope_fields_from_packet_info(packet_info)
+        if dec_rt == 0:
+            return 0
+        return rt
+
     def _is_old_cached_message(self, timestamp: Any) -> bool:
         """Check if a message timestamp indicates it's from before bot connection.
 
@@ -1949,6 +2063,7 @@ class MessageHandler:
                 extended_timeout = self.rf_data_timeout * 2  # Double the normal timeout
                 recent_rf_data = self.find_recent_rf_data(max_age_seconds=extended_timeout)
 
+            packet_info: dict[str, Any] | None = None
             if recent_rf_data and recent_rf_data.get("raw_hex"):
                 raw_hex = recent_rf_data["raw_hex"]
                 self.logger.info(f"🔍 FOUND RF DATA: {len(raw_hex)} chars, starts with: {raw_hex[:32]}...")
@@ -2026,27 +2141,10 @@ class MessageHandler:
             # use the same scope so it reaches the same scoped network segment.
             reply_scope: str | None = None
             if recent_rf_data:
-                rt = recent_rf_data.get("route_type_int")
-                tc_code1 = recent_rf_data.get("transport_code1")
-                scope_payload_type = recent_rf_data.get("payload_type_int")
-                scope_payload_hex = recent_rf_data.get("scope_payload_hex") or ""
                 scope_keys = getattr(getattr(self.bot, "command_manager", None), "flood_scope_keys", {})
-                if (
-                    rt == 0  # TRANSPORT_FLOOD (TC_FLOOD)
-                    and tc_code1 is not None
-                    and scope_payload_type is not None
-                    and scope_payload_hex
-                ):
-                    pkt_payload_bytes = bytes.fromhex(scope_payload_hex)
-                    reply_scope = self._match_scope(tc_code1, scope_payload_type, pkt_payload_bytes, scope_keys)
-                    if reply_scope:
-                        self.logger.info(f"Incoming TC_FLOOD matched scope '{reply_scope}'; reply will use same scope")
-                elif scope_keys:
-                    self.logger.debug(
-                        f"Scope check: route_type={rt} (need 0=TC_FLOOD), "
-                        f"tc_code1={'set' if tc_code1 is not None else 'None'}, "
-                        f"payload_type={scope_payload_type}"
-                    )
+                reply_scope = self._resolve_reply_scope_from_rf_data(
+                    recent_rf_data, packet_info, scope_keys
+                )
 
             # Allowlist enforcement: when flood_scopes is configured, only reply to
             # messages whose scope matched an entry.  Unscoped FLOOD is allowed only
@@ -2055,7 +2153,7 @@ class MessageHandler:
             scope_keys = getattr(cmd_mgr, "flood_scope_keys", {})
             if scope_keys and reply_scope is None:
                 allow_global = getattr(cmd_mgr, "flood_scope_allow_global", False)
-                rt_for_check = recent_rf_data.get("route_type_int") if recent_rf_data else None
+                rt_for_check = self._effective_route_type_int(recent_rf_data, packet_info)
                 if rt_for_check == 0:
                     self.logger.info("Ignoring TC_FLOOD: scope not in flood_scopes allowlist")
                     return

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -639,10 +639,10 @@ class MessageHandler:
                 # Track this advertisement in the complete database
                 if hasattr(self.bot, "repeater_manager"):
                     # Track all advertisements regardless of type
-                    success = await self.bot.repeater_manager.track_contact_advertisement(
+                    track_result = await self.bot.repeater_manager.track_contact_advertisement(
                         advert_data, signal_info, packet_hash=packet_hash
                     )
-                    if success:
+                    if track_result.ok:
                         # Log rich advert information
                         mode = advert_data.get("mode", "Unknown")
                         name = advert_data.get("name", "No name")
@@ -3425,7 +3425,7 @@ class MessageHandler:
                         auto_manage_setting,
                     )
 
-                    await self.bot.repeater_manager.track_contact_advertisement(
+                    track_result = await self.bot.repeater_manager.track_contact_advertisement(
                         contact_data, signal_info, packet_hash=packet_hash
                     )
 
@@ -3452,35 +3452,42 @@ class MessageHandler:
                                 contact_name,
                             )
                     elif auto_manage_setting == "bot":
-                        self.logger.info(
-                            "Bot mode — adding companion %s to device with capacity management",
-                            contact_name,
-                        )
-                        try:
-                            self._ensure_contact_meshcore_path_encoding(contact_data)
-                            ok = await self.bot.repeater_manager.add_companion_from_contact_data(
-                                contact_data, contact_name, public_key
-                            )
-                            if not ok:
-                                self.logger.warning(
-                                    "Failed to add companion contact %s to device after managed add/retry",
-                                    contact_name,
-                                )
-                        except Exception as e:
-                            self.logger.error("Error adding companion %s to device: %s", contact_name, e)
-
-                        status = await self.bot.repeater_manager.get_contact_list_status()
-                        if status and status.get("is_near_limit", False):
-                            self.logger.warning(
-                                "Contact list near limit (%.1f%%) — managing capacity after add",
-                                status["usage_percentage"],
-                            )
-                            await self.bot.repeater_manager.manage_contact_list(auto_cleanup=True)
-                        else:
-                            self.logger.info(
-                                "Companion %s — contact list has adequate space after add attempt",
+                        # packet_hash dedupe: when absent, every NEW_CONTACT may still trigger add_contact.
+                        if track_result.duplicate_packet:
+                            self.logger.debug(
+                                "Skipping add_companion — duplicate packet_hash for %s (already tracked)",
                                 contact_name,
                             )
+                        else:
+                            self.logger.info(
+                                "Bot mode — adding companion %s to device with capacity management",
+                                contact_name,
+                            )
+                            try:
+                                self._ensure_contact_meshcore_path_encoding(contact_data)
+                                ok = await self.bot.repeater_manager.add_companion_from_contact_data(
+                                    contact_data, contact_name, public_key
+                                )
+                                if not ok:
+                                    self.logger.warning(
+                                        "Failed to add companion contact %s to device after managed add/retry",
+                                        contact_name,
+                                    )
+                            except Exception as e:
+                                self.logger.error("Error adding companion %s to device: %s", contact_name, e)
+
+                            status = await self.bot.repeater_manager.get_contact_list_status()
+                            if status and status.get("is_near_limit", False):
+                                self.logger.warning(
+                                    "Contact list near limit (%.1f%%) — managing capacity after add",
+                                    status["usage_percentage"],
+                                )
+                                await self.bot.repeater_manager.manage_contact_list(auto_cleanup=True)
+                            else:
+                                self.logger.info(
+                                    "Companion %s — contact list has adequate space after add attempt",
+                                    contact_name,
+                                )
                     else:
                         self.logger.warning(
                             "Unknown auto_manage_contacts value %r — treating as manual for %s",

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -3082,15 +3082,11 @@ class MessageHandler:
                 command_id = f"keyword_{keyword}_{message.sender_id}_{int(time.time())}"
 
                 try:
-                    rate_limit_key = self.bot.command_manager.get_rate_limit_key(message)
-                    if message.is_dm:
-                        success = await self.bot.command_manager.send_dm(
-                            message.sender_id, response, command_id, rate_limit_key=rate_limit_key
-                        )
-                    else:
-                        success = await self.bot.command_manager.send_channel_message(
-                            message.channel, response, command_id, rate_limit_key=rate_limit_key
-                        )
+                    success = await self.bot.command_manager.send_response(
+                        message,
+                        response,
+                        command_id=command_id,
+                    )
 
                     if not success:
                         self.logger.warning(
@@ -3127,15 +3123,11 @@ class MessageHandler:
                 command_id = f"randomline_{key}_{message.sender_id}_{int(time.time())}"
 
                 try:
-                    rate_limit_key = self.bot.command_manager.get_rate_limit_key(message)
-                    if message.is_dm:
-                        success = await self.bot.command_manager.send_dm(
-                            message.sender_id, response, command_id, rate_limit_key=rate_limit_key
-                        )
-                    else:
-                        success = await self.bot.command_manager.send_channel_message(
-                            message.channel, response, command_id, rate_limit_key=rate_limit_key
-                        )
+                    success = await self.bot.command_manager.send_response(
+                        message,
+                        response,
+                        command_id=command_id,
+                    )
 
                     if not success:
                         self.logger.warning(

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -1533,8 +1533,12 @@ class MessageHandler:
             if hasattr(self, "debug") and self.debug:
                 self.logger.debug(f"ADVERT flags: 0x{flags_byte:02X} (binary: {flags_byte:08b})")
 
-            # Create flags object with the full byte value
-            flags = AdvertFlags(flags_byte)
+            # Bit tests match firmware AdvertDataParser (do not use AdvertFlags(flags_byte):
+            # enum.Flag rejects some valid uint8 values, e.g. corrupt wires or type nibble > 4).
+            has_latlon = (flags_byte & AdvertFlags.ADV_LATLON_MASK.value) != 0
+            has_feat1 = (flags_byte & AdvertFlags.ADV_FEAT1_MASK.value) != 0
+            has_feat2 = (flags_byte & AdvertFlags.ADV_FEAT2_MASK.value) != 0
+            has_name = (flags_byte & AdvertFlags.ADV_NAME_MASK.value) != 0
 
             advert = {
                 "public_key": pub_key.hex(),
@@ -1559,7 +1563,7 @@ class MessageHandler:
             i = 1  # Start after flags byte
 
             # Parse location data if present (matches C++ hasLatLon())
-            if AdvertFlags.ADV_LATLON_MASK in flags:
+            if has_latlon:
                 if len(app_data) < i + 8:
                     self.logger.error(f"ADVERT with location flag too short: {len(app_data)} bytes")
                     return advert
@@ -1570,7 +1574,7 @@ class MessageHandler:
                 i += 8
 
             # Parse feat1 data if present
-            if AdvertFlags.ADV_FEAT1_MASK in flags:
+            if has_feat1:
                 if len(app_data) < i + 2:
                     self.logger.error(f"ADVERT with feat1 flag too short: {len(app_data)} bytes")
                     return advert
@@ -1579,7 +1583,7 @@ class MessageHandler:
                 i += 2
 
             # Parse feat2 data if present
-            if AdvertFlags.ADV_FEAT2_MASK in flags:
+            if has_feat2:
                 if len(app_data) < i + 2:
                     self.logger.error(f"ADVERT with feat2 flag too short: {len(app_data)} bytes")
                     return advert
@@ -1588,7 +1592,7 @@ class MessageHandler:
                 i += 2
 
             # Parse name data if present (matches C++ hasName())
-            if AdvertFlags.ADV_NAME_MASK in flags and len(app_data) >= i:
+            if has_name and len(app_data) >= i:
                 name_len = len(app_data) - i
                 if name_len > 0:
                     try:
@@ -1601,7 +1605,7 @@ class MessageHandler:
             return advert
 
         except Exception as e:
-            self.logger.error(f"Error parsing ADVERT payload: {e}", exc_info=True)
+            self.logger.warning(f"Error parsing ADVERT payload: {e}")
             return {}
 
     def _path_bytes_to_nodes(self, path_bytes: bytes, prefix_hex_chars: int | None = None) -> tuple:

--- a/modules/repeater_manager.py
+++ b/modules/repeater_manager.py
@@ -8,12 +8,23 @@ import asyncio
 import json
 import time
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, NamedTuple, Optional
 
 from meshcore import EventType
 
 from .security_utils import sanitize_name, validate_pubkey_format
 from .utils import rate_limited_nominatim_reverse_sync
+
+
+class TrackAdvertResult(NamedTuple):
+    """Result of track_contact_advertisement.
+
+    ok: tracking succeeded, or duplicate packet is OK (not an error).
+    duplicate_packet: same packet_hash already processed for this public_key — skip redundant radio work.
+    """
+
+    ok: bool
+    duplicate_packet: bool = False
 
 
 def collect_protected_pubkeys_for_device_mode(config: Any, logger: Any) -> set[str]:
@@ -179,8 +190,10 @@ class RepeaterManager:
             self.logger.error(f"Failed to initialize repeater database: {e}")
             raise
 
-    async def track_contact_advertisement(self, advert_data: dict, signal_info: Optional[dict] = None, packet_hash: Optional[str] = None) -> bool:
-        """Track any contact advertisement in the complete tracking database"""
+    async def track_contact_advertisement(
+        self, advert_data: dict, signal_info: Optional[dict] = None, packet_hash: Optional[str] = None
+    ) -> TrackAdvertResult:
+        """Track any contact advertisement in the complete tracking database."""
         try:
             # Extract basic information
             public_key = advert_data.get('public_key', '')
@@ -189,7 +202,7 @@ class RepeaterManager:
 
             if not public_key:
                 self.logger.warning("No public key in advertisement data")
-                return False
+                return TrackAdvertResult(ok=False, duplicate_packet=False)
 
             # Determine role and device type
             role = self._determine_contact_role(advert_data)
@@ -229,7 +242,7 @@ class RepeaterManager:
                     if existing_packet:
                         # This packet_hash was already processed - skip contact update
                         self.logger.debug(f"Skipping duplicate advert packet for {name}: {packet_hash[:8]}... (already processed)")
-                        return True  # Return True since packet was already tracked (not an error)
+                        return TrackAdvertResult(ok=True, duplicate_packet=True)
 
                 # Check if this contact is already in our complete tracking
                 existing = self.db_manager.execute_query_on_connection(
@@ -315,11 +328,11 @@ class RepeaterManager:
 
                 conn.commit()
 
-            return True
+            return TrackAdvertResult(ok=True, duplicate_packet=False)
 
         except Exception as e:
             self.logger.error(f"Error tracking contact advertisement: {e}")
-            return False
+            return TrackAdvertResult(ok=False, duplicate_packet=False)
 
     def _track_daily_advertisement_on_conn(self, conn, public_key: str, name: str, role: str, device_type: str,
                                             location_info: dict, signal_strength: Optional[float], snr: Optional[float],

--- a/modules/response_template.py
+++ b/modules/response_template.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Piped placeholders for command response templates (feed-style ``{field|filter:args}``).
+
+Used by :class:`~modules.commands.test_command.TestCommand` and extensible for other
+commands. Same brace limitation as feed formatting: no nested ``{}`` inside a placeholder.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from .utils import message_path_bytes_per_hop
+
+FilterFn = Callable[[str, dict[str, Any], str], str]
+
+
+def _filter_pathbytes_min(value: str, ctx: dict[str, Any], args: str) -> str:
+    """Clear *value* unless message path uses at least *N* bytes per hop (N in 1..3)."""
+    message = ctx.get('message')
+    if message is None:
+        return ''
+    try:
+        n = int(args.strip())
+    except ValueError:
+        return value
+    if n < 1 or n > 3:
+        return value
+    prefix_hex = int(ctx.get('prefix_hex_chars') or 2)
+    bph = message_path_bytes_per_hop(message, prefix_hex_chars=prefix_hex)
+    if bph < n:
+        return ''
+    return value
+
+
+def _filter_prefix_if_nonempty(value: str, ctx: dict[str, Any], args: str) -> str:
+    """Prepend *args* literal to *value* only when *value* is non-empty after prior filters."""
+    if not value:
+        return ''
+    return args + value
+
+
+RESPONSE_TEMPLATE_FILTERS: dict[str, FilterFn] = {
+    'pathbytes_min': _filter_pathbytes_min,
+    'pathbytes': _filter_pathbytes_min,
+    'prefix_if_nonempty': _filter_prefix_if_nonempty,
+}
+
+
+def _field_and_filter_specs(inner: str) -> tuple[str, list[tuple[str, str]]]:
+    """Split ``inner`` into field name and ``(filter_name, args)`` pairs.
+
+    Pipe ``|`` separates filters. ``prefix_if_nonempty`` is special: its argument may
+    contain ``|`` (e.g. `` | Path Dist: ``), so once that filter is reached we merge
+    all remaining segments and treat the rest as its args. ``prefix_if_nonempty`` must
+    be last in the chain if the literal includes a pipe.
+    """
+    raw_parts = inner.split('|')
+    field_name = raw_parts[0].strip()
+    if len(raw_parts) < 2:
+        return field_name, []
+    specs: list[tuple[str, str]] = []
+    i = 1
+    while i < len(raw_parts):
+        if raw_parts[i].lstrip().startswith('prefix_if_nonempty'):
+            merged = '|'.join(raw_parts[i:])
+            if re.match(r'^\s*prefix_if_nonempty\s*$', merged):
+                specs.append(('prefix_if_nonempty', ''))
+                break
+            m = re.match(r'^\s*prefix_if_nonempty\s*:(.*)$', merged, flags=re.DOTALL)
+            if m:
+                specs.append(('prefix_if_nonempty', m.group(1)))
+            else:
+                specs.append(('prefix_if_nonempty', ''))
+            break
+        segment = raw_parts[i].strip()
+        name, sep, arg = segment.partition(':')
+        name = name.strip()
+        arg = arg if sep else ''
+        specs.append((name, arg))
+        i += 1
+    return field_name, specs
+
+
+def format_piped_template(
+    template: str,
+    fields: dict[str, str],
+    *,
+    message: Any = None,
+    logger: Any = None,
+    prefix_hex_chars: int = 2,
+) -> str:
+    """Replace ``{field}`` and ``{field|filter:arg|...}`` using *fields* and optional *message*.
+
+    Args:
+        template: Raw template string from config.
+        fields: Mapping of placeholder names to string values (e.g. ``sender``, ``path_distance``).
+        message: Triggering mesh message; required for ``pathbytes`` / ``pathbytes_min`` filters.
+        logger: Optional logger for unknown filter warnings.
+        prefix_hex_chars: Bot prefix width for inferring bytes per hop from legacy path text.
+
+    Returns:
+        Fully expanded string.
+    """
+    ctx: dict[str, Any] = {
+        'message': message,
+        'logger': logger,
+        'prefix_hex_chars': prefix_hex_chars,
+    }
+
+    def replace_placeholder(match: re.Match[str]) -> str:
+        inner_raw = match.group(1)
+        if '|' not in inner_raw:
+            return str(fields.get(inner_raw.strip(), ''))
+        field_name, filter_specs = _field_and_filter_specs(inner_raw)
+        value = str(fields.get(field_name, ''))
+        for name, arg in filter_specs:
+            fn = RESPONSE_TEMPLATE_FILTERS.get(name)
+            if fn is None:
+                if logger is not None:
+                    logger.warning(f"Unknown response template filter {name!r} in {{{inner_raw}}}")
+                continue
+            value = fn(value, ctx, arg)
+        return value
+
+    return re.sub(r"\{([^}]+)\}", replace_placeholder, template)

--- a/modules/scheduled_message_cron.py
+++ b/modules/scheduled_message_cron.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-Parse [Scheduled_Messages] option keys into APScheduler CronTrigger instances.
+Parse ``[Scheduled_Messages]`` option keys into APScheduler CronTrigger instances,
+and option values into ``(channel, message, scope)`` for optional regional flood scope.
 
-Supports:
+Supports (schedule keys):
 - Standard 5-field crontab: minute hour day-of-month month day-of-week
 - Preset aliases: @yearly, @annually, @monthly, @weekly, @daily, @midnight, @hourly
 - Deprecated legacy HHMM (24-hour, no colon) for daily firing at that clock time
@@ -14,6 +15,38 @@ from dataclasses import dataclass
 from typing import Optional
 
 from apscheduler.triggers.cron import CronTrigger
+
+
+def parse_scheduled_message_value(raw: str) -> tuple[str, str, str | None]:
+    """Parse a ``[Scheduled_Messages]`` option value into ``(channel, message, scope)``.
+
+    **Legacy (unscoped):** ``channel:body`` — split on the first ``:`` only; ``scope`` is
+    ``None`` (global flood).
+
+    **Scoped:** ``channel:#region:body`` — exactly three segments from ``split(':', 2)``
+    where the middle segment starts with ``#`` after strip. The message body may contain
+    further colons. Scope must not contain ``:``.
+
+    Args:
+        raw: Config value, e.g. ``Public:Hello`` or ``Public:#sea:Hello: more``.
+
+    Returns:
+        ``(channel, message, scope)`` with ``scope`` set only for the scoped form.
+
+    Raises:
+        ValueError: If there is no ``:`` (cannot separate channel from body).
+    """
+    s = (raw or "").strip()
+    if ":" not in s:
+        raise ValueError("scheduled message value must be channel:message")
+    parts = s.split(":", 2)
+    if len(parts) == 3 and parts[1].strip().startswith("#"):
+        channel = parts[0].strip()
+        scope = parts[1].strip()
+        message = parts[2].strip()
+        return channel, message, scope
+    channel, message = s.split(":", 1)
+    return channel.strip(), message.strip(), None
 
 # Maps @preset (lowercase) -> 5-field crontab (APScheduler does not accept @syntax in from_crontab).
 _SPECIAL_PRESET_TO_CRON: dict[str, str] = {

--- a/modules/scheduled_message_cron.py
+++ b/modules/scheduled_message_cron.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Parse [Scheduled_Messages] option keys into APScheduler CronTrigger instances.
+
+Supports:
+- Standard 5-field crontab: minute hour day-of-month month day-of-week
+- Preset aliases: @yearly, @annually, @monthly, @weekly, @daily, @midnight, @hourly
+- Deprecated legacy HHMM (24-hour, no colon) for daily firing at that clock time
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from apscheduler.triggers.cron import CronTrigger
+
+# Maps @preset (lowercase) -> 5-field crontab (APScheduler does not accept @syntax in from_crontab).
+_SPECIAL_PRESET_TO_CRON: dict[str, str] = {
+    "@yearly": "0 0 1 1 *",
+    "@annually": "0 0 1 1 *",
+    "@monthly": "0 0 1 * *",
+    "@weekly": "0 0 * * 0",
+    "@daily": "0 0 * * *",
+    "@midnight": "0 0 * * *",
+    "@hourly": "0 * * * *",
+}
+
+
+@dataclass(frozen=True)
+class ScheduleParseResult:
+    """Outcome of parsing a scheduled message key."""
+
+    trigger: Optional[CronTrigger]
+    """APScheduler trigger, or None if the expression is invalid."""
+
+    display_label: str
+    """Human-readable schedule for logs and the ``schedule`` command."""
+
+    is_deprecated_hhmm: bool
+    """True when the legacy HHMM daily form was used."""
+
+
+def is_valid_legacy_hhmm(time_str: str) -> bool:
+    """Return True if ``time_str`` is a valid legacy HHMM clock time (24h)."""
+    try:
+        if len(time_str) != 4 or not time_str.isdigit():
+            return False
+        hour = int(time_str[:2])
+        minute = int(time_str[2:])
+        return 0 <= hour <= 23 and 0 <= minute <= 59
+    except ValueError:
+        return False
+
+
+def parse_schedule_key(
+    schedule_key: str,
+    timezone,
+) -> ScheduleParseResult:
+    """Parse a ``[Scheduled_Messages]`` option name into a :class:`CronTrigger`.
+
+    Args:
+        schedule_key: Raw config option key (e.g. ``0 9 * * *``, ``@daily``, ``0900``).
+        timezone: ``tzinfo`` or string accepted by APScheduler (same as scheduler).
+
+    Returns:
+        ScheduleParseResult with ``trigger`` set when valid, else ``trigger`` is None
+        and ``display_label`` still describes what was attempted.
+    """
+    raw = (schedule_key or "").strip()
+    if not raw:
+        return ScheduleParseResult(None, "", False)
+
+    lowered = raw.lower()
+
+    # 1) Deprecated legacy HHMM (must be checked before numeric cron fragments).
+    if is_valid_legacy_hhmm(raw):
+        hour = int(raw[:2])
+        minute = int(raw[2:])
+        trigger = CronTrigger(hour=hour, minute=minute, timezone=timezone)
+        display = f"{hour:02d}:{minute:02d}"
+        return ScheduleParseResult(trigger, display, True)
+
+    # 2) @preset aliases
+    if lowered in _SPECIAL_PRESET_TO_CRON:
+        cron_expr = _SPECIAL_PRESET_TO_CRON[lowered]
+        try:
+            trigger = CronTrigger.from_crontab(cron_expr, timezone=timezone)
+        except ValueError:
+            return ScheduleParseResult(None, raw, False)
+        return ScheduleParseResult(trigger, raw, False)
+
+    # 3) Standard 5-field crontab
+    try:
+        trigger = CronTrigger.from_crontab(raw, timezone=timezone)
+    except ValueError:
+        return ScheduleParseResult(None, raw, False)
+    return ScheduleParseResult(trigger, raw, False)

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -6,6 +6,7 @@ Handles scheduled messages and timing
 
 import asyncio
 import datetime
+import hashlib
 import json
 import os
 import sqlite3
@@ -15,11 +16,11 @@ from pathlib import Path
 from typing import Any, Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from meshcore.events import EventType
 
 from .maintenance import MaintenanceRunner
+from .scheduled_message_cron import is_valid_legacy_hhmm, parse_schedule_key
 from .security_utils import validate_external_url
 from .utils import decode_escape_sequences, format_keyword_response_with_placeholders, get_config_timezone
 
@@ -73,33 +74,51 @@ class MessageScheduler:
 
         if self.bot.config.has_section('Scheduled_Messages'):
             self.logger.info("Found Scheduled_Messages section")
-            for time_str, message_info in self.bot.config.items('Scheduled_Messages'):
-                self.logger.info(f"Processing scheduled message: '{time_str}' -> '{message_info}'")
+            for schedule_key, message_info in self.bot.config.items('Scheduled_Messages'):
+                self.logger.info(f"Processing scheduled message: '{schedule_key}' -> '{message_info}'")
                 try:
-                    # Validate time format first
-                    if not self._is_valid_time_format(time_str):
-                        self.logger.warning(f"Invalid time format '{time_str}' for scheduled message: {message_info}")
+                    parsed = parse_schedule_key(schedule_key, tz)
+                    if parsed.trigger is None:
+                        self.logger.warning(
+                            f"Invalid schedule '{schedule_key}' for scheduled message: {message_info}"
+                        )
                         continue
+
+                    if parsed.is_deprecated_hhmm:
+                        hh = int(schedule_key[:2])
+                        mm = int(schedule_key[2:])
+                        cron_suggestion = f"{mm} {hh} * * *"
+                        self.logger.warning(
+                            "Scheduled_Messages key %r uses deprecated HHMM daily format; "
+                            "migrate to 5-field cron (minute hour dom mon dow), e.g. %r. "
+                            "HHMM support will be removed in a future release.",
+                            schedule_key,
+                            cron_suggestion,
+                        )
 
                     channel, message = message_info.split(':', 1)
                     channel = channel.strip()
                     message = decode_escape_sequences(message.strip())
-                    hour = int(time_str[:2])
-                    minute = int(time_str[2:])
+
+                    job_id = "schedmsg_" + hashlib.sha256(
+                        f"{schedule_key}\0{channel}\0{message}".encode()
+                    ).hexdigest()[:24]
 
                     self._apscheduler.add_job(
                         self.send_scheduled_message,
-                        CronTrigger(hour=hour, minute=minute),
+                        parsed.trigger,
                         args=[channel, message],
-                        id=f"msg_{time_str}_{channel}",
+                        id=job_id,
                         replace_existing=True,
                     )
-                    self.scheduled_messages[time_str] = (channel, message)
-                    self.logger.info(f"Scheduled message: {hour:02d}:{minute:02d} -> {channel}: {message}")
+                    self.scheduled_messages[schedule_key] = (channel, message, parsed.display_label)
+                    self.logger.info(
+                        f"Scheduled message: {parsed.display_label} -> {channel}: {message}"
+                    )
                 except ValueError:
                     self.logger.warning(f"Invalid scheduled message format: {message_info}")
                 except Exception as e:
-                    self.logger.warning(f"Error setting up scheduled message '{time_str}': {e}")
+                    self.logger.warning(f"Error setting up scheduled message '{schedule_key}': {e}")
 
         self._apscheduler.start()
         self.logger.info(f"APScheduler started with {len(self.scheduled_messages)} scheduled message(s)")
@@ -202,15 +221,8 @@ class MessageScheduler:
         self._run_async_on_main_loop(self._device_mode_favourite_pass2_coro(), timeout=600.0)
 
     def _is_valid_time_format(self, time_str: str) -> bool:
-        """Validate time format (HHMM)"""
-        try:
-            if len(time_str) != 4:
-                return False
-            hour = int(time_str[:2])
-            minute = int(time_str[2:])
-            return 0 <= hour <= 23 and 0 <= minute <= 59
-        except ValueError:
-            return False
+        """Validate deprecated legacy time format (HHMM). Prefer cron in config keys."""
+        return is_valid_legacy_hhmm(time_str)
 
     def send_scheduled_message(self, channel: str, message: str):
         """Send a scheduled message (synchronous wrapper for schedule library)"""

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -24,8 +24,6 @@ from .scheduled_message_cron import is_valid_legacy_hhmm, parse_schedule_key
 from .security_utils import validate_external_url
 from .utils import decode_escape_sequences, format_keyword_response_with_placeholders, get_config_timezone
 
-# process_message_queue may await long per-feed intervals across many queued items; 30s is too short.
-_FEED_MESSAGE_QUEUE_FUTURE_TIMEOUT = 600
 
 
 class MessageScheduler:
@@ -560,39 +558,23 @@ class MessageScheduler:
                     )
                 self.last_radio_ops_check_time = time.time()
 
-            # Process feed message queue (every 2 seconds)
-            if time.time() - self.last_message_queue_check_time >= 2:  # Every 2 seconds
+            # Process feed message queue (every 2 seconds, fire-and-forget)
+            # process_message_queue() returns immediately if a run is already in progress,
+            # so we never block this thread waiting for per-feed send intervals.
+            if time.time() - self.last_message_queue_check_time >= 2:
                 if (hasattr(self.bot, 'feed_manager') and self.bot.feed_manager and
                     hasattr(self.bot, 'connected') and self.bot.connected):
                     import asyncio
                     if hasattr(self.bot, 'main_event_loop') and self.bot.main_event_loop and self.bot.main_event_loop.is_running():
-                        # Schedule coroutine in the running main event loop
                         future = asyncio.run_coroutine_threadsafe(
                             self.bot.feed_manager.process_message_queue(),
                             self.bot.main_event_loop
                         )
-                        try:
-                            future.result(timeout=_FEED_MESSAGE_QUEUE_FUTURE_TIMEOUT)
-                        except TimeoutError:
-                            self.logger.warning(
-                                "Timed out waiting for feed message queue after %ss; "
-                                "work may still be running on the main loop (per-feed send spacing).",
-                                _FEED_MESSAGE_QUEUE_FUTURE_TIMEOUT,
-                            )
-                        except RuntimeError as e:
-                            self.logger.warning("Event loop gone during feed message queue: %s", e)
-                        except Exception as e:
-                            self.logger.exception(f"Error processing message queue: {e}")
-                    else:
-                        # Fallback: create new event loop if main loop not available
-                        try:
-                            loop = asyncio.get_event_loop()
-                        except RuntimeError:
-                            loop = asyncio.new_event_loop()
-                            asyncio.set_event_loop(loop)
-
-                        loop.run_until_complete(self.bot.feed_manager.process_message_queue())
-                    self.last_message_queue_check_time = time.time()
+                        future.add_done_callback(
+                            lambda f: self.logger.exception("Error processing message queue: %s", f.exception())
+                            if not f.cancelled() and f.exception() else None
+                        )
+                self.last_message_queue_check_time = time.time()
 
             # Data retention: run daily (packet_stream, repeater tables, stats, caches, mesh_connections)
             if time.time() - self.last_data_retention_run >= self._data_retention_interval_seconds:

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -20,10 +20,13 @@ from apscheduler.triggers.date import DateTrigger
 from meshcore.events import EventType
 
 from .maintenance import MaintenanceRunner
-from .scheduled_message_cron import is_valid_legacy_hhmm, parse_schedule_key
+from .scheduled_message_cron import (
+    is_valid_legacy_hhmm,
+    parse_schedule_key,
+    parse_scheduled_message_value,
+)
 from .security_utils import validate_external_url
 from .utils import decode_escape_sequences, format_keyword_response_with_placeholders, get_config_timezone
-
 
 
 class MessageScheduler:
@@ -94,25 +97,30 @@ class MessageScheduler:
                             cron_suggestion,
                         )
 
-                    channel, message = message_info.split(':', 1)
-                    channel = channel.strip()
-                    message = decode_escape_sequences(message.strip())
+                    channel, message, scope = parse_scheduled_message_value(message_info)
+                    message = decode_escape_sequences(message)
 
                     job_id = "schedmsg_" + hashlib.sha256(
-                        f"{schedule_key}\0{channel}\0{message}".encode()
+                        f"{schedule_key}\0{channel}\0{scope or ''}\0{message}".encode()
                     ).hexdigest()[:24]
 
                     self._apscheduler.add_job(
                         self.send_scheduled_message,
                         parsed.trigger,
                         args=[channel, message],
-                        kwargs={"schedule_key": schedule_key},
+                        kwargs={"schedule_key": schedule_key, "scope": scope},
                         id=job_id,
                         replace_existing=True,
                     )
-                    self.scheduled_messages[schedule_key] = (channel, message, parsed.display_label)
+                    self.scheduled_messages[schedule_key] = (
+                        channel,
+                        message,
+                        parsed.display_label,
+                        scope,
+                    )
+                    scope_note = f" scope={scope}" if scope else ""
                     self.logger.info(
-                        f"Scheduled message: {parsed.display_label} -> {channel}: {message}"
+                        f"Scheduled message: {parsed.display_label} -> {channel}{scope_note}: {message}"
                     )
                 except ValueError:
                     self.logger.warning(f"Invalid scheduled message format: {message_info}")
@@ -234,7 +242,13 @@ class MessageScheduler:
         slot = int.from_bytes(digest[:4], "big") / (2**32)
         return float(slot * max_s)
 
-    def send_scheduled_message(self, channel: str, message: str, schedule_key: str = ""):
+    def send_scheduled_message(
+        self,
+        channel: str,
+        message: str,
+        schedule_key: str = "",
+        scope: str | None = None,
+    ):
         """Send a scheduled message (synchronous wrapper for schedule library)"""
         if self.bot.is_radio_zombie:
             self.logger.warning("send_scheduled_message suppressed — radio is in zombie state")
@@ -244,7 +258,11 @@ class MessageScheduler:
             return
 
         current_time = self.get_current_time()
-        self.logger.info(f"📅 Sending scheduled message at {current_time.strftime('%H:%M:%S')} to {channel}: {message}")
+        scope_note = f" [{scope}]" if scope else ""
+        self.logger.info(
+            f"📅 Sending scheduled message at {current_time.strftime('%H:%M:%S')} "
+            f"to {channel}{scope_note}: {message}"
+        )
 
         import asyncio
 
@@ -253,8 +271,10 @@ class MessageScheduler:
         if hasattr(self.bot, 'main_event_loop') and self.bot.main_event_loop and self.bot.main_event_loop.is_running():
             # Schedule coroutine in the running main event loop
             future = asyncio.run_coroutine_threadsafe(
-                self._send_scheduled_message_async(channel, message, schedule_key=schedule_key),
-                self.bot.main_event_loop
+                self._send_scheduled_message_async(
+                    channel, message, schedule_key=schedule_key, scope=scope
+                ),
+                self.bot.main_event_loop,
             )
             # Wait for completion (with timeout to prevent indefinite blocking)
             try:
@@ -270,7 +290,9 @@ class MessageScheduler:
             loop = asyncio.new_event_loop()
             try:
                 loop.run_until_complete(
-                    self._send_scheduled_message_async(channel, message, schedule_key=schedule_key)
+                    self._send_scheduled_message_async(
+                        channel, message, schedule_key=schedule_key, scope=scope
+                    )
                 )
             finally:
                 loop.close()
@@ -432,7 +454,12 @@ class MessageScheduler:
         return any(placeholder in message for placeholder in placeholders)
 
     async def _send_scheduled_message_async(
-        self, channel: str, message: str, *, schedule_key: str = ""
+        self,
+        channel: str,
+        message: str,
+        *,
+        schedule_key: str = "",
+        scope: str | None = None,
     ):
         """Send a scheduled message (async implementation)"""
         stagger = self._scheduled_message_stagger_seconds(schedule_key)
@@ -464,7 +491,7 @@ class MessageScheduler:
         send_timeout = self.bot.config.getint('Bot', 'send_timeout_seconds', fallback=30)
         await _asyncio.wait_for(
             self.bot.command_manager.send_channel_message(
-                channel, message, skip_user_rate_limit=True
+                channel, message, skip_user_rate_limit=True, scope=scope
             ),
             timeout=send_timeout,
         )

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -106,6 +106,7 @@ class MessageScheduler:
                         self.send_scheduled_message,
                         parsed.trigger,
                         args=[channel, message],
+                        kwargs={"schedule_key": schedule_key},
                         id=job_id,
                         replace_existing=True,
                     )
@@ -222,7 +223,18 @@ class MessageScheduler:
         """Validate deprecated legacy time format (HHMM). Prefer cron in config keys."""
         return is_valid_legacy_hhmm(time_str)
 
-    def send_scheduled_message(self, channel: str, message: str):
+    def _scheduled_message_stagger_seconds(self, schedule_key: str) -> float:
+        """Deterministic delay in [0, max) so simultaneous cron jobs do not stack on the radio."""
+        max_s = self.bot.config.getfloat(
+            "Bot", "scheduled_message_max_stagger_seconds", fallback=1.5
+        )
+        if max_s <= 0 or not (schedule_key or "").strip():
+            return 0.0
+        digest = hashlib.sha256(schedule_key.encode("utf-8")).digest()
+        slot = int.from_bytes(digest[:4], "big") / (2**32)
+        return float(slot * max_s)
+
+    def send_scheduled_message(self, channel: str, message: str, schedule_key: str = ""):
         """Send a scheduled message (synchronous wrapper for schedule library)"""
         if self.bot.is_radio_zombie:
             self.logger.warning("send_scheduled_message suppressed — radio is in zombie state")
@@ -241,7 +253,7 @@ class MessageScheduler:
         if hasattr(self.bot, 'main_event_loop') and self.bot.main_event_loop and self.bot.main_event_loop.is_running():
             # Schedule coroutine in the running main event loop
             future = asyncio.run_coroutine_threadsafe(
-                self._send_scheduled_message_async(channel, message),
+                self._send_scheduled_message_async(channel, message, schedule_key=schedule_key),
                 self.bot.main_event_loop
             )
             # Wait for completion (with timeout to prevent indefinite blocking)
@@ -257,7 +269,9 @@ class MessageScheduler:
             # Fallback: create a temporary event loop and close it when done
             loop = asyncio.new_event_loop()
             try:
-                loop.run_until_complete(self._send_scheduled_message_async(channel, message))
+                loop.run_until_complete(
+                    self._send_scheduled_message_async(channel, message, schedule_key=schedule_key)
+                )
             finally:
                 loop.close()
 
@@ -417,8 +431,17 @@ class MessageScheduler:
         ]
         return any(placeholder in message for placeholder in placeholders)
 
-    async def _send_scheduled_message_async(self, channel: str, message: str):
+    async def _send_scheduled_message_async(
+        self, channel: str, message: str, *, schedule_key: str = ""
+    ):
         """Send a scheduled message (async implementation)"""
+        stagger = self._scheduled_message_stagger_seconds(schedule_key)
+        if stagger > 0:
+            self.logger.debug(
+                "Scheduled message stagger %.2fs (schedule_key=%r)", stagger, schedule_key
+            )
+            await asyncio.sleep(stagger)
+
         # Check if message contains mesh info placeholders
         if self._has_mesh_info_placeholders(message):
             try:
@@ -440,7 +463,9 @@ class MessageScheduler:
         import asyncio as _asyncio
         send_timeout = self.bot.config.getint('Bot', 'send_timeout_seconds', fallback=30)
         await _asyncio.wait_for(
-            self.bot.command_manager.send_channel_message(channel, message),
+            self.bot.command_manager.send_channel_message(
+                channel, message, skip_user_rate_limit=True
+            ),
             timeout=send_timeout,
         )
 

--- a/modules/service_plugins/base_service.py
+++ b/modules/service_plugins/base_service.py
@@ -40,6 +40,11 @@ class BaseServicePlugin(ABC):
     that both transmit mesh channel messages and call ``send_external_notifications``
     should skip ``send_channel_message`` when this is true so alerts go only to
     webhook/Telegram. Subclasses implement the guard at their mesh send sites.
+
+    **Regional flood scope:** optional ``flood_scope`` in this plugin's config section
+    (e.g. ``#west``). Use ``get_mesh_flood_scope()`` when calling
+    ``send_channel_message``; omit the key to inherit
+    ``[Channels] outgoing_flood_scope_override``.
     """
 
     # Optional: Config section name (if different from class name)
@@ -108,6 +113,22 @@ class BaseServicePlugin(ABC):
         if self._external_notify_cache is None:
             self._external_notify_cache = self._parse_external_notify_settings()
         return self._external_notify_cache
+
+    def get_mesh_flood_scope(self) -> str | None:
+        """Optional regional TC_FLOOD scope from this plugin's config section.
+
+        Reads ``flood_scope`` from ``config_section``. When omitted, returns ``None``
+        so ``send_channel_message`` uses ``[Channels] outgoing_flood_scope_override``.
+        """
+        from modules.command_manager import CommandManager
+
+        section = self.config_section or self._derive_config_section()
+        if not self.bot.config.has_section(section):
+            return None
+        raw = (self.bot.config.get(section, "flood_scope", fallback="") or "").strip()
+        if not raw:
+            return None
+        return CommandManager._normalize_scope_name(raw)
 
     def has_external_notification_targets(self) -> bool:
         """True if Discord URLs are set, or Telegram chats plus a resolved bot token."""

--- a/modules/service_plugins/base_service.py
+++ b/modules/service_plugins/base_service.py
@@ -234,7 +234,8 @@ class BaseServicePlugin(ABC):
         """
         class_name = self.__class__.__name__
         if class_name.endswith('Service'):
-            return class_name[:-7].lower()  # Remove 'Service' suffix and lowercase
+            # Remove 'Service' suffix and lowercase
+            return class_name[:-7].lower().strip('_')
         return class_name.lower()
 
     def _derive_config_section(self) -> str:

--- a/modules/service_plugins/darc_mowas_service.py
+++ b/modules/service_plugins/darc_mowas_service.py
@@ -191,7 +191,7 @@ class DARC_MoWaS_Service(BaseServicePlugin):
                     chunk,
                     i,
                     len(chunks),
-                    ts_now + timedelta(seconds=1)
+                    ts_now + timedelta(seconds=i)
                 )
             )
 
@@ -215,7 +215,8 @@ class DARC_MoWaS_Service(BaseServicePlugin):
                 chunk,
                 command_id=cmd_id,
                 skip_user_rate_limit=True,
-                timestamp=timestamp
+                timestamp=timestamp,
+                scope=self.get_mesh_flood_scope(),
             ):
                 self.logger.warning("Send failed for '%s'", channel)
                 return

--- a/modules/service_plugins/darc_mowas_service.py
+++ b/modules/service_plugins/darc_mowas_service.py
@@ -19,7 +19,7 @@ import time
 import xml.dom.minidom
 from asyncio import AbstractEventLoop
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, cast
 
 import aiohttp
@@ -176,11 +176,14 @@ class DARC_MoWaS_Service(BaseServicePlugin):
         Send all chunks, each with async retry if configured.
         Note, that we cannot guarantee that the messages arrive in-order,
         but as the chunks have a (x/n) identifier at the end, the user still
-        should be able to grasp the message correctly.
+        should be able to grasp the message correctly. We further add
+        an ascending timestamp to each message (also used on re-transmission) to
+        let the client restore the order, as well as deduplicate retransmissions.
 
         Ideally this chunking should be implemented at protocol level to
         guarantee the atomicity and order of the full message.
         """
+        ts_now = datetime.now()
         for i, chunk in enumerate(chunks):
             asyncio.create_task(
                 self._send_chunk_with_retry(
@@ -188,6 +191,7 @@ class DARC_MoWaS_Service(BaseServicePlugin):
                     chunk,
                     i,
                     len(chunks),
+                    ts_now + timedelta(seconds=1)
                 )
             )
 
@@ -197,6 +201,7 @@ class DARC_MoWaS_Service(BaseServicePlugin):
         chunk: str,
         index: int,
         total: int,
+        timestamp: datetime,
     ) -> None:
         """Send a chunk and retry until acked or retries exhausted."""
         tracker = getattr(self.bot, "transmission_tracker", None)
@@ -210,6 +215,7 @@ class DARC_MoWaS_Service(BaseServicePlugin):
                 chunk,
                 command_id=cmd_id,
                 skip_user_rate_limit=True,
+                timestamp=timestamp
             ):
                 self.logger.warning("Send failed for '%s'", channel)
                 return

--- a/modules/service_plugins/earthquake_service.py
+++ b/modules/service_plugins/earthquake_service.py
@@ -167,12 +167,12 @@ class EarthquakeService(BaseServicePlugin):
                 text = self._format_quake(quake)
                 if text:
                     await self.bot.command_manager.send_channel_message(
-                        self.channel, text
+                        self.channel, text, scope=self.get_mesh_flood_scope()
                     )
                     url_detail = props.get("url", "")
                     if self.send_link and url_detail:
                         await self.bot.command_manager.send_channel_message(
-                            self.channel, url_detail
+                            self.channel, url_detail, scope=self.get_mesh_flood_scope()
                         )
                     self.logger.info("Earthquake alert sent: %s", event_id)
                 self.seen_event_ids.add(event_id)

--- a/modules/service_plugins/map_uploader_service.py
+++ b/modules/service_plugins/map_uploader_service.py
@@ -629,7 +629,10 @@ class MapUploaderService(BaseServicePlugin):
                 return None
 
             flags_byte = app_data[0]
-            flags = AdvertFlags(flags_byte)
+            has_latlon = (flags_byte & AdvertFlags.ADV_LATLON_MASK.value) != 0
+            has_feat1 = (flags_byte & AdvertFlags.ADV_FEAT1_MASK.value) != 0
+            has_feat2 = (flags_byte & AdvertFlags.ADV_FEAT2_MASK.value) != 0
+            has_name = (flags_byte & AdvertFlags.ADV_NAME_MASK.value) != 0
 
             # Extract type
             adv_type = flags_byte & 0x0F
@@ -651,7 +654,7 @@ class MapUploaderService(BaseServicePlugin):
 
             # Parse location data if present
             i = 1
-            if AdvertFlags.ADV_LATLON_MASK in flags and len(app_data) >= i + 8:
+            if has_latlon and len(app_data) >= i + 8:
                 lat = int.from_bytes(app_data[i:i+4], 'little', signed=True)
                 lon = int.from_bytes(app_data[i+4:i+8], 'little', signed=True)
                 advert['lat'] = round(lat / 1000000.0, 6)
@@ -659,15 +662,15 @@ class MapUploaderService(BaseServicePlugin):
                 i += 8
 
             # Parse feat1 data if present
-            if AdvertFlags.ADV_FEAT1_MASK in flags:
+            if has_feat1:
                 i += 2
 
             # Parse feat2 data if present
-            if AdvertFlags.ADV_FEAT2_MASK in flags:
+            if has_feat2:
                 i += 2
 
             # Parse name if present
-            if AdvertFlags.ADV_NAME_MASK in flags and len(app_data) >= i:
+            if has_name and len(app_data) >= i:
                 try:
                     name = app_data[i:].decode('utf-8', errors='ignore').rstrip('\x00')
                     advert['name'] = name
@@ -677,7 +680,7 @@ class MapUploaderService(BaseServicePlugin):
             return advert
 
         except Exception as e:
-            self.logger.error(f"Error parsing advert: {e}")
+            self.logger.warning(f"Error parsing advert: {e}")
             return None
 
     async def _verify_advert_signature(self, advert: dict[str, Any], payload: bytes) -> bool:

--- a/modules/service_plugins/packet_capture_service.py
+++ b/modules/service_plugins/packet_capture_service.py
@@ -50,7 +50,7 @@ class PacketCaptureService(BaseServicePlugin):
     Supports multiple MQTT brokers, auth tokens, and output to file.
     """
 
-    config_section = 'PacketCapture'  # Explicit config section
+    config_section = "PacketCapture"  # Explicit config section
     description = "Captures packets from MeshCore network and publishes to MQTT"
 
     def __init__(self, bot):
@@ -65,7 +65,7 @@ class PacketCaptureService(BaseServicePlugin):
         # Use self.meshcore property to get current connection
 
         # Setup logging (use bot's formatter and configuration)
-        self.logger = logging.getLogger('PacketCaptureService')
+        self.logger = logging.getLogger("PacketCaptureService")
         self.logger.setLevel(bot.logger.level)
 
         # Only setup handlers if none exist to prevent duplicates
@@ -82,30 +82,32 @@ class PacketCaptureService(BaseServicePlugin):
             if not bot_formatter:
                 try:
                     import colorlog
-                    colored = (bot.config.getboolean('Logging', 'colored_output', fallback=True)
-                               if bot.config.has_section('Logging') else True)
+
+                    colored = (
+                        bot.config.getboolean("Logging", "colored_output", fallback=True)
+                        if bot.config.has_section("Logging")
+                        else True
+                    )
                     if colored:
                         bot_formatter = colorlog.ColoredFormatter(
-                            '%(log_color)s%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                            datefmt='%Y-%m-%d %H:%M:%S',
+                            "%(log_color)s%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                            datefmt="%Y-%m-%d %H:%M:%S",
                             log_colors={
-                                'DEBUG': 'cyan',
-                                'INFO': 'green',
-                                'WARNING': 'yellow',
-                                'ERROR': 'red',
-                                'CRITICAL': 'red,bg_white',
-                            }
+                                "DEBUG": "cyan",
+                                "INFO": "green",
+                                "WARNING": "yellow",
+                                "ERROR": "red",
+                                "CRITICAL": "red,bg_white",
+                            },
                         )
                     else:
                         bot_formatter = logging.Formatter(
-                            '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                            datefmt='%Y-%m-%d %H:%M:%S'
+                            "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
                         )
                 except ImportError:
                     # Fallback if colorlog not available
                     bot_formatter = logging.Formatter(
-                        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                        datefmt='%Y-%m-%d %H:%M:%S'
+                        "%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
                     )
 
             # Add console handler with bot's formatter
@@ -131,8 +133,8 @@ class PacketCaptureService(BaseServicePlugin):
         self.mqtt_connected = False
 
         # Stats/status publishing
-        self.stats_status_enabled = self.get_config_bool('stats_in_status_enabled', True)
-        self.stats_refresh_interval = self.get_config_int('stats_refresh_interval', 300)
+        self.stats_status_enabled = self.get_config_bool("stats_in_status_enabled", True)
+        self.stats_refresh_interval = self.get_config_int("stats_refresh_interval", 300)
         self.latest_stats = None
         self.last_stats_fetch = 0
         self.stats_supported = False
@@ -146,12 +148,13 @@ class PacketCaptureService(BaseServicePlugin):
         self.background_tasks: list[asyncio.Task] = []
         self.should_exit = False
 
-        # JWT renewal (default: 12 hours, tokens valid for 24 hours)
-        self.jwt_renewal_interval = self.get_config_int('jwt_renewal_interval', 43200)
+        # JWT renewal (default: 12 hours) and JWT exp TTL (default: 24 hours; see jwt_ttl_seconds)
+        self.jwt_renewal_interval = self.get_config_int("jwt_renewal_interval", 43200)
+        self.jwt_ttl_seconds = self.get_config_int("jwt_ttl_seconds", 86400)
 
         # Health check
-        self.health_check_interval = self.get_config_int('health_check_interval', 30)
-        self.health_check_grace_period = self.get_config_int('health_check_grace_period', 2)
+        self.health_check_interval = self.get_config_int("health_check_interval", 30)
+        self.health_check_grace_period = self.get_config_int("health_check_grace_period", 2)
         self.health_check_failure_count = 0
 
         # Event subscriptions (track for cleanup)
@@ -174,28 +177,28 @@ class PacketCaptureService(BaseServicePlugin):
         config = self.bot.config
 
         # Check if enabled
-        self.enabled = config.getboolean('PacketCapture', 'enabled', fallback=False)
+        self.enabled = config.getboolean("PacketCapture", "enabled", fallback=False)
 
         # Output file
-        self.output_file = config.get('PacketCapture', 'output_file', fallback=None)
+        self.output_file = config.get("PacketCapture", "output_file", fallback=None)
 
         # Verbose/debug
-        self.verbose = config.getboolean('PacketCapture', 'verbose', fallback=False)
-        self.debug = config.getboolean('PacketCapture', 'debug', fallback=False)
+        self.verbose = config.getboolean("PacketCapture", "verbose", fallback=False)
+        self.debug = config.getboolean("PacketCapture", "debug", fallback=False)
 
         # MQTT configuration
-        self.mqtt_enabled = config.getboolean('PacketCapture', 'mqtt_enabled', fallback=True)
+        self.mqtt_enabled = config.getboolean("PacketCapture", "mqtt_enabled", fallback=True)
         self.mqtt_brokers = self._parse_mqtt_brokers(config)
 
         # Global IATA
-        self.global_iata = config.get('PacketCapture', 'iata', fallback='XYZ').lower()
+        self.global_iata = config.get("PacketCapture", "iata", fallback="XYZ").lower()
 
         # Owner information
-        self.owner_public_key = config.get('PacketCapture', 'owner_public_key', fallback=None)
-        self.owner_email = config.get('PacketCapture', 'owner_email', fallback=None)
+        self.owner_public_key = config.get("PacketCapture", "owner_public_key", fallback=None)
+        self.owner_email = config.get("PacketCapture", "owner_email", fallback=None)
 
         # Private key for auth tokens (fallback if device signing not available)
-        self.private_key_path = config.get('PacketCapture', 'private_key_path', fallback=None)
+        self.private_key_path = config.get("PacketCapture", "private_key_path", fallback=None)
         self.private_key_hex = None
         if self.private_key_path:
             self.private_key_hex = read_private_key_file(self.private_key_path)
@@ -203,26 +206,22 @@ class PacketCaptureService(BaseServicePlugin):
                 self.logger.warning(f"Could not load private key from {self.private_key_path}")
 
         # Auth token method preference
-        self.auth_token_method = config.get('PacketCapture', 'auth_token_method', fallback='device').lower()
+        self.auth_token_method = config.get("PacketCapture", "auth_token_method", fallback="device").lower()
         # 'device' = try on-device signing first, fallback to Python
         # 'python' = use Python signing only
 
         # RX_LOG vs RAW correlation (mirror meshcore-packet-capture RAW_DUPLICATE_WINDOW / RF_DATA_TIMEOUT)
-        self.raw_duplicate_window = config.getfloat(
-            'PacketCapture', 'raw_duplicate_window', fallback=2.0
-        )
-        self.rf_data_cache_timeout = config.getfloat(
-            'PacketCapture', 'rf_data_cache_timeout', fallback=15.0
-        )
+        self.raw_duplicate_window = config.getfloat("PacketCapture", "raw_duplicate_window", fallback=2.0)
+        self.rf_data_cache_timeout = config.getfloat("PacketCapture", "rf_data_cache_timeout", fallback=15.0)
 
         # Do not publish to MQTT when content hash is unknown (zeros) — unparseable / strict path reject
         self.mqtt_skip_unparseable_packets = config.getboolean(
-            'PacketCapture', 'mqtt_skip_unparseable_packets', fallback=True
+            "PacketCapture", "mqtt_skip_unparseable_packets", fallback=True
         )
 
         # Skip MQTT for ADVERT packets that fail Ed25519 verify (mesh payload corruption)
         self.advert_require_valid_signature = config.getboolean(
-            'PacketCapture', 'advert_require_valid_signature', fallback=False
+            "PacketCapture", "advert_require_valid_signature", fallback=False
         )
 
         # Note: Python signing can fetch private key from device if not provided via file
@@ -237,12 +236,10 @@ class PacketCaptureService(BaseServicePlugin):
         if current_time is None:
             current_time = time.time()
         self.rf_data_cache = {
-            k: v for k, v in self.rf_data_cache.items()
-            if current_time - v['timestamp'] < self.rf_data_cache_timeout
+            k: v for k, v in self.rf_data_cache.items() if current_time - v["timestamp"] < self.rf_data_cache_timeout
         }
         self.recent_rf_packets = {
-            k: v for k, v in self.recent_rf_packets.items()
-            if current_time - v < self.raw_duplicate_window
+            k: v for k, v in self.recent_rf_packets.items() if current_time - v < self.raw_duplicate_window
         }
 
     def _parse_mqtt_brokers(self, config) -> list[dict[str, Any]]:
@@ -256,49 +253,68 @@ class PacketCaptureService(BaseServicePlugin):
         """
         brokers = []
 
+        global_jwt_renewal = config.getint("PacketCapture", "jwt_renewal_interval", fallback=43200)
+        global_jwt_ttl = config.getint("PacketCapture", "jwt_ttl_seconds", fallback=86400)
+
         # Parse multiple brokers (mqtt1_*, mqtt2_*, etc.)
         broker_num = 1
         while True:
-            enabled_key = f'mqtt{broker_num}_enabled'
-            server_key = f'mqtt{broker_num}_server'
+            enabled_key = f"mqtt{broker_num}_enabled"
+            server_key = f"mqtt{broker_num}_server"
 
-            if not config.has_option('PacketCapture', server_key):
+            if not config.has_option("PacketCapture", server_key):
                 break
 
-            enabled = config.getboolean('PacketCapture', enabled_key, fallback=True)
+            enabled = config.getboolean("PacketCapture", enabled_key, fallback=True)
             if not enabled:
                 broker_num += 1
                 continue
 
             # Parse upload_packet_types: comma-separated list (e.g. "2,4"); empty/unset = upload all
-            upload_types_raw = config.get('PacketCapture', f'mqtt{broker_num}_upload_packet_types', fallback='').strip()
+            upload_types_raw = config.get("PacketCapture", f"mqtt{broker_num}_upload_packet_types", fallback="").strip()
             upload_packet_types = None
             if upload_types_raw:
-                upload_packet_types = frozenset(t.strip() for t in upload_types_raw.split(',') if t.strip())
+                upload_packet_types = frozenset(t.strip() for t in upload_types_raw.split(",") if t.strip())
                 if not upload_packet_types:
                     upload_packet_types = None
 
+            renew_key = f"mqtt{broker_num}_jwt_renewal_interval"
+            if config.has_option("PacketCapture", renew_key):
+                jwt_renewal_interval = config.getint("PacketCapture", renew_key)
+            else:
+                jwt_renewal_interval = global_jwt_renewal
+
+            ttl_key = f"mqtt{broker_num}_jwt_ttl_seconds"
+            if config.has_option("PacketCapture", ttl_key):
+                jwt_ttl_seconds = config.getint("PacketCapture", ttl_key)
+            else:
+                jwt_ttl_seconds = global_jwt_ttl
+
             broker = {
-                'enabled': True,
-                'host': config.get('PacketCapture', server_key, fallback='localhost'),
-                'port': config.getint('PacketCapture', f'mqtt{broker_num}_port', fallback=1883),
-                'username': config.get('PacketCapture', f'mqtt{broker_num}_username', fallback=None),
-                'password': config.get('PacketCapture', f'mqtt{broker_num}_password', fallback=None),
-                'topic_prefix': config.get('PacketCapture', f'mqtt{broker_num}_topic_prefix', fallback=None),
-                'topic_status': config.get('PacketCapture', f'mqtt{broker_num}_topic_status', fallback=None),
-                'topic_packets': config.get('PacketCapture', f'mqtt{broker_num}_topic_packets', fallback=None),
-                'use_auth_token': config.getboolean('PacketCapture', f'mqtt{broker_num}_use_auth_token', fallback=False),
-                'token_audience': config.get('PacketCapture', f'mqtt{broker_num}_token_audience', fallback=None),
-                'transport': config.get('PacketCapture', f'mqtt{broker_num}_transport', fallback='tcp').lower(),
-                'use_tls': config.getboolean('PacketCapture', f'mqtt{broker_num}_use_tls', fallback=False),
-                'websocket_path': config.get('PacketCapture', f'mqtt{broker_num}_websocket_path', fallback='/mqtt'),
-                'client_id': config.get('PacketCapture', f'mqtt{broker_num}_client_id', fallback=None),
-                'upload_packet_types': upload_packet_types,
+                "enabled": True,
+                "host": config.get("PacketCapture", server_key, fallback="localhost"),
+                "port": config.getint("PacketCapture", f"mqtt{broker_num}_port", fallback=1883),
+                "username": config.get("PacketCapture", f"mqtt{broker_num}_username", fallback=None),
+                "password": config.get("PacketCapture", f"mqtt{broker_num}_password", fallback=None),
+                "topic_prefix": config.get("PacketCapture", f"mqtt{broker_num}_topic_prefix", fallback=None),
+                "topic_status": config.get("PacketCapture", f"mqtt{broker_num}_topic_status", fallback=None),
+                "topic_packets": config.get("PacketCapture", f"mqtt{broker_num}_topic_packets", fallback=None),
+                "use_auth_token": config.getboolean(
+                    "PacketCapture", f"mqtt{broker_num}_use_auth_token", fallback=False
+                ),
+                "token_audience": config.get("PacketCapture", f"mqtt{broker_num}_token_audience", fallback=None),
+                "transport": config.get("PacketCapture", f"mqtt{broker_num}_transport", fallback="tcp").lower(),
+                "use_tls": config.getboolean("PacketCapture", f"mqtt{broker_num}_use_tls", fallback=False),
+                "websocket_path": config.get("PacketCapture", f"mqtt{broker_num}_websocket_path", fallback="/mqtt"),
+                "client_id": config.get("PacketCapture", f"mqtt{broker_num}_client_id", fallback=None),
+                "upload_packet_types": upload_packet_types,
+                "jwt_renewal_interval": jwt_renewal_interval,
+                "jwt_ttl_seconds": jwt_ttl_seconds,
             }
 
             # Set default topic_prefix if not set
-            if not broker['topic_prefix']:
-                broker['topic_prefix'] = 'meshcore/packets'
+            if not broker["topic_prefix"]:
+                broker["topic_prefix"] = "meshcore/packets"
 
             brokers.append(broker)
             broker_num += 1
@@ -315,7 +331,7 @@ class PacketCaptureService(BaseServicePlugin):
         Returns:
             bool: Config value or fallback.
         """
-        return self.bot.config.getboolean('PacketCapture', key, fallback=fallback)
+        return self.bot.config.getboolean("PacketCapture", key, fallback=fallback)
 
     def get_config_int(self, key: str, fallback: int = 0) -> int:
         """Get integer config value.
@@ -327,7 +343,7 @@ class PacketCaptureService(BaseServicePlugin):
         Returns:
             int: Config value or fallback.
         """
-        return self.bot.config.getint('PacketCapture', key, fallback=fallback)
+        return self.bot.config.getint("PacketCapture", key, fallback=fallback)
 
     def get_config_float(self, key: str, fallback: float = 0.0) -> float:
         """Get float config value.
@@ -339,9 +355,9 @@ class PacketCaptureService(BaseServicePlugin):
         Returns:
             float: Config value or fallback.
         """
-        return self.bot.config.getfloat('PacketCapture', key, fallback=fallback)
+        return self.bot.config.getfloat("PacketCapture", key, fallback=fallback)
 
-    def get_config_str(self, key: str, fallback: str = '') -> str:
+    def get_config_str(self, key: str, fallback: str = "") -> str:
         """Get string config value.
 
         Args:
@@ -351,7 +367,26 @@ class PacketCaptureService(BaseServicePlugin):
         Returns:
             str: Config value or fallback.
         """
-        return self.bot.config.get('PacketCapture', key, fallback=fallback)
+        return self.bot.config.get("PacketCapture", key, fallback=fallback)
+
+    def _auth_token_iat_exp(self, broker_config: dict[str, Any]) -> tuple[int, int]:
+        """Unix iat/exp for JWT payload (exp = iat + ttl). Non-positive TTL uses 86400s."""
+        iat = int(time.time())
+        ttl = int(broker_config.get("jwt_ttl_seconds", self.jwt_ttl_seconds))
+        if ttl <= 0:
+            ttl = 86400
+        return iat, iat + ttl
+
+    @staticmethod
+    def _jwt_ttl_log_phrase(ttl_seconds: int) -> str:
+        """Short TTL description for log lines."""
+        if ttl_seconds >= 3600 and ttl_seconds % 3600 == 0:
+            h = ttl_seconds // 3600
+            return f"{h} hours" if h != 1 else "1 hour"
+        if ttl_seconds >= 60 and ttl_seconds % 60 == 0:
+            m = ttl_seconds // 60
+            return f"{m} minutes" if m != 1 else "1 minute"
+        return f"{ttl_seconds}s"
 
     @property
     def meshcore(self):
@@ -395,7 +430,7 @@ class PacketCaptureService(BaseServicePlugin):
         # Open output file if specified
         if self.output_file:
             try:
-                self.output_handle = open(self.output_file, 'a')
+                self.output_handle = open(self.output_file, "a")
                 self.logger.info(f"Writing packets to: {self.output_file}")
             except Exception as e:
                 self.logger.error(f"Failed to open output file: {e}")
@@ -418,7 +453,9 @@ class PacketCaptureService(BaseServicePlugin):
 
         self.connected = True
         self._running = True
-        self.logger.info(f"Packet capture service started (MQTT: {'connected' if self.mqtt_connected else 'not connected'})")
+        self.logger.info(
+            f"Packet capture service started (MQTT: {'connected' if self.mqtt_connected else 'not connected'})"
+        )
 
     async def stop(self) -> None:
         """Stop the packet capture service.
@@ -444,8 +481,8 @@ class PacketCaptureService(BaseServicePlugin):
         # Disconnect MQTT
         for mqtt_client_info in self.mqtt_clients:
             try:
-                mqtt_client_info['client'].disconnect()
-                mqtt_client_info['client'].loop_stop()
+                mqtt_client_info["client"].disconnect()
+                mqtt_client_info["client"].loop_stop()
             except (AttributeError, RuntimeError, OSError) as e:
                 # Silently ignore expected errors during cleanup (client already disconnected, etc.)
                 self.logger.debug(f"Error disconnecting MQTT client during cleanup: {e}")
@@ -489,10 +526,7 @@ class PacketCaptureService(BaseServicePlugin):
         self.meshcore.subscribe(EventType.RX_LOG_DATA, on_rx_log_data)
         self.meshcore.subscribe(EventType.RAW_DATA, on_raw_data)
 
-        self.event_subscriptions = [
-            (EventType.RX_LOG_DATA, on_rx_log_data),
-            (EventType.RAW_DATA, on_raw_data)
-        ]
+        self.event_subscriptions = [(EventType.RX_LOG_DATA, on_rx_log_data), (EventType.RAW_DATA, on_raw_data)]
 
         self.logger.info("Packet capture event handlers registered")
 
@@ -505,22 +539,22 @@ class PacketCaptureService(BaseServicePlugin):
         """
         try:
             # Copy payload immediately to avoid segfault if event is freed
-            payload = copy.deepcopy(event.payload) if hasattr(event, 'payload') else None
+            payload = copy.deepcopy(event.payload) if hasattr(event, "payload") else None
             if payload is None:
                 self.logger.warning("RX log data event has no payload")
                 return
 
-            if 'snr' in payload:
+            if "snr" in payload:
                 # Try to get packet data - prefer 'payload' field, fallback to 'raw_hex'
                 # This matches the original script's logic exactly
                 raw_hex = None
 
                 # First, try the 'payload' field (already stripped of framing bytes)
-                if 'payload' in payload and payload['payload']:
-                    raw_hex = payload['payload']
+                if "payload" in payload and payload["payload"]:
+                    raw_hex = payload["payload"]
                 # Fallback to raw_hex with first 2 bytes stripped
-                elif 'raw_hex' in payload and payload['raw_hex']:
-                    raw_hex = payload['raw_hex'][4:]  # Skip first 2 bytes (4 hex chars)
+                elif "raw_hex" in payload and payload["raw_hex"]:
+                    raw_hex = payload["raw_hex"][4:]  # Skip first 2 bytes (4 hex chars)
 
                 if raw_hex:
                     if self.debug:
@@ -531,10 +565,10 @@ class PacketCaptureService(BaseServicePlugin):
                     current_time = time.time()
                     packet_prefix = raw_hex[:32] if len(raw_hex) >= 32 else raw_hex
                     self.rf_data_cache[packet_prefix] = {
-                        'snr': payload.get('snr'),
-                        'rssi': payload.get('rssi'),
-                        'timestamp': current_time,
-                        'payload_length': payload.get('payload_length'),
+                        "snr": payload.get("snr"),
+                        "rssi": payload.get("rssi"),
+                        "timestamp": current_time,
+                        "payload_length": payload.get("payload_length"),
                     }
                     self.recent_rf_packets[raw_hex.upper()] = current_time
                     self._prune_correlation_caches(current_time)
@@ -542,7 +576,9 @@ class PacketCaptureService(BaseServicePlugin):
                     # Process packet
                     await self.process_packet(raw_hex, payload, metadata)
                 else:
-                    self.logger.warning(f"RF log data missing both 'payload' and 'raw_hex' fields: {list(payload.keys())}")
+                    self.logger.warning(
+                        f"RF log data missing both 'payload' and 'raw_hex' fields: {list(payload.keys())}"
+                    )
 
         except Exception as e:
             self.logger.error(f"Error handling RX log data: {e}")
@@ -559,19 +595,19 @@ class PacketCaptureService(BaseServicePlugin):
         """
         try:
             # Copy payload immediately to avoid segfault if event is freed
-            payload = copy.deepcopy(event.payload) if hasattr(event, 'payload') else None
+            payload = copy.deepcopy(event.payload) if hasattr(event, "payload") else None
             if payload is None:
                 self.logger.warning("Raw data event has no payload")
                 return
 
             raw_hex_src = None
-            if hasattr(payload, 'data'):
+            if hasattr(payload, "data"):
                 raw_hex_src = payload.data
             elif isinstance(payload, dict):
-                if 'data' in payload:
-                    raw_hex_src = payload['data']
-                elif 'raw_hex' in payload:
-                    raw_hex_src = payload['raw_hex']
+                if "data" in payload:
+                    raw_hex_src = payload["data"]
+                elif "raw_hex" in payload:
+                    raw_hex_src = payload["raw_hex"]
 
             if raw_hex_src is None:
                 return
@@ -580,7 +616,7 @@ class PacketCaptureService(BaseServicePlugin):
                 raw_hex = raw_hex_src.hex()
             elif isinstance(raw_hex_src, str):
                 raw_hex = raw_hex_src
-                if raw_hex.startswith('0x'):
+                if raw_hex.startswith("0x"):
                     raw_hex = raw_hex[2:]
             else:
                 return
@@ -591,14 +627,11 @@ class PacketCaptureService(BaseServicePlugin):
             recent_rf_time = self.recent_rf_packets.get(raw_hex)
             if recent_rf_time is not None and (current_time - recent_rf_time) < self.raw_duplicate_window:
                 if self.debug:
-                    self.logger.debug(
-                        "Skipping RAW_DATA packet already processed from RX_LOG_DATA (duplicate raw hex)"
-                    )
+                    self.logger.debug("Skipping RAW_DATA packet already processed from RX_LOG_DATA (duplicate raw hex)")
                 return
 
             self.recent_rf_packets = {
-                k: v for k, v in self.recent_rf_packets.items()
-                if current_time - v < self.raw_duplicate_window
+                k: v for k, v in self.recent_rf_packets.items() if current_time - v < self.raw_duplicate_window
             }
 
             packet_prefix = raw_hex[:32] if len(raw_hex) >= 32 else raw_hex
@@ -611,18 +644,20 @@ class PacketCaptureService(BaseServicePlugin):
                 merged_payload = {}
 
             if rf_cached:
-                merged_payload.setdefault('snr', rf_cached.get('snr'))
-                merged_payload.setdefault('rssi', rf_cached.get('rssi'))
-                pl = merged_payload.get('payload_length')
+                merged_payload.setdefault("snr", rf_cached.get("snr"))
+                merged_payload.setdefault("rssi", rf_cached.get("rssi"))
+                pl = merged_payload.get("payload_length")
                 if pl is None:
-                    merged_payload['payload_length'] = rf_cached.get('payload_length')
+                    merged_payload["payload_length"] = rf_cached.get("payload_length")
 
             await self.process_packet(raw_hex, merged_payload, metadata)
 
         except Exception as e:
             self.logger.error(f"Error handling raw data: {e}")
 
-    def _format_packet_data(self, raw_hex: str, packet_info: dict[str, Any], payload: dict[str, Any], metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _format_packet_data(
+        self, raw_hex: str, packet_info: dict[str, Any], payload: dict[str, Any], metadata: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Format packet data to match original script's format_packet_data exactly.
 
         Args:
@@ -638,18 +673,12 @@ class PacketCaptureService(BaseServicePlugin):
         timestamp = current_time.isoformat()
 
         # Remove 0x prefix if present
-        clean_raw_hex = raw_hex.replace('0x', '').upper()
+        clean_raw_hex = raw_hex.replace("0x", "").upper()
         packet_len = len(clean_raw_hex) // 2  # Convert hex string to byte count
 
         # Map route type to single letter (matches original script)
-        route_map = {
-            "TRANSPORT_FLOOD": "F",
-            "FLOOD": "F",
-            "DIRECT": "D",
-            "TRANSPORT_DIRECT": "T",
-            "UNKNOWN": "U"
-        }
-        route = route_map.get(packet_info.get('route_type', 'UNKNOWN'), "U")
+        route_map = {"TRANSPORT_FLOOD": "F", "FLOOD": "F", "DIRECT": "D", "TRANSPORT_DIRECT": "T", "UNKNOWN": "U"}
+        route = route_map.get(packet_info.get("route_type", "UNKNOWN"), "U")
 
         # Map payload type to string number (matches original script)
         payload_type_map = {
@@ -669,23 +698,23 @@ class PacketCaptureService(BaseServicePlugin):
             "Type13": "13",
             "Type14": "14",
             "RAW_CUSTOM": "15",
-            "UNKNOWN": "0"
+            "UNKNOWN": "0",
         }
-        packet_type = payload_type_map.get(packet_info.get('payload_type', 'UNKNOWN'), "0")
+        packet_type = payload_type_map.get(packet_info.get("payload_type", "UNKNOWN"), "0")
 
         # MQTT payload_len: byte length of application payload after header/transport/path.
         # Subtract path *bytes*, not hop count (multi-byte path IDs); prefer decoded size.
-        firmware_payload_len = payload.get('payload_length')
-        decoded_ok = packet_info.get('payload_type', 'UNKNOWN') != 'UNKNOWN'
-        if decoded_ok and 'payload_bytes' in packet_info:
-            payload_len = str(packet_info['payload_bytes'])
+        firmware_payload_len = payload.get("payload_length")
+        decoded_ok = packet_info.get("payload_type", "UNKNOWN") != "UNKNOWN"
+        if decoded_ok and "payload_bytes" in packet_info:
+            payload_len = str(packet_info["payload_bytes"])
         elif firmware_payload_len is not None:
             payload_len = str(firmware_payload_len)
         else:
-            path_bytes = packet_info.get('path_byte_length')
+            path_bytes = packet_info.get("path_byte_length")
             if path_bytes is None:
-                path_bytes = packet_info.get('path_len', 0)
-            has_transport = packet_info.get('has_transport_codes', False)
+                path_bytes = packet_info.get("path_len", 0)
+            has_transport = packet_info.get("has_transport_codes", False)
             transport_bytes = 4 if has_transport else 0
             payload_len = str(max(0, packet_len - 1 - transport_bytes - 1 - path_bytes))
 
@@ -696,12 +725,12 @@ class PacketCaptureService(BaseServicePlugin):
 
         # Get device public key for origin_id
         origin_id = None
-        if self.meshcore and hasattr(self.meshcore, 'self_info'):
+        if self.meshcore and hasattr(self.meshcore, "self_info"):
             try:
                 self_info = self.meshcore.self_info
                 if isinstance(self_info, dict):
-                    origin_id = self_info.get('public_key', '')
-                elif hasattr(self_info, 'public_key'):
+                    origin_id = self_info.get("public_key", "")
+                elif hasattr(self_info, "public_key"):
                     origin_id = self_info.public_key
 
                 # Convert to hex string if bytes
@@ -713,29 +742,29 @@ class PacketCaptureService(BaseServicePlugin):
                 pass
 
         # Normalize origin_id to uppercase
-        origin_id = origin_id.replace('0x', '').replace(' ', '').upper() if origin_id else 'UNKNOWN'
+        origin_id = origin_id.replace("0x", "").replace(" ", "").upper() if origin_id else "UNKNOWN"
 
         # Extract RF data
-        snr = str(payload.get('snr', 'Unknown'))
-        rssi = str(payload.get('rssi', 'Unknown'))
+        snr = str(payload.get("snr", "Unknown"))
+        rssi = str(payload.get("rssi", "Unknown"))
 
         # Get packet hash from decoded packet_info — same clean bytes as the upload's "raw" field,
         # so this is always the correct hash (matches what other observers compute).
-        packet_hash = packet_info.get('packet_hash', '0000000000000000')
+        packet_hash = packet_info.get("packet_hash", "0000000000000000")
 
         # Only fall back to direct calculation if decode_packet didn't produce a hash
-        if packet_hash == '0000000000000000':
+        if packet_hash == "0000000000000000":
             try:
-                payload_type_value = packet_info.get('payload_type_value')
+                payload_type_value = packet_info.get("payload_type_value")
                 if payload_type_value is not None:
-                    if hasattr(payload_type_value, 'value'):
+                    if hasattr(payload_type_value, "value"):
                         payload_type_value = payload_type_value.value
                     payload_type_value = int(payload_type_value) & 0x0F
                 packet_hash = calculate_packet_hash(clean_raw_hex, payload_type_value)
             except Exception as e:
                 if self.debug:
                     self.logger.debug(f"Error calculating packet hash: {e}")
-                packet_hash = '0000000000000000'
+                packet_hash = "0000000000000000"
 
         # Build packet data structure (matches original script exactly)
         packet_data = {
@@ -753,22 +782,24 @@ class PacketCaptureService(BaseServicePlugin):
             "raw": clean_raw_hex,
             "SNR": snr,
             "RSSI": rssi,
-            "hash": packet_hash
+            "hash": packet_hash,
         }
 
         # Add optional fields from payload if present (score, duration, etc.)
-        if 'score' in payload:
-            packet_data['score'] = str(payload['score'])
-        if 'duration' in payload:
-            packet_data['duration'] = str(payload['duration'])
+        if "score" in payload:
+            packet_data["score"] = str(payload["score"])
+        if "duration" in payload:
+            packet_data["duration"] = str(payload["duration"])
 
         # Add path for route=D (matches original script)
-        if route == "D" and packet_info.get('path'):
-            packet_data["path"] = ",".join(packet_info['path'])
+        if route == "D" and packet_info.get("path"):
+            packet_data["path"] = ",".join(packet_info["path"])
 
         return packet_data
 
-    async def process_packet(self, raw_hex: str, payload: dict[str, Any], metadata: dict[str, Any] | None = None) -> None:
+    async def process_packet(
+        self, raw_hex: str, payload: dict[str, Any], metadata: dict[str, Any] | None = None
+    ) -> None:
         """Process a captured packet.
 
         Decodes the packet, formats it, writes to file, and publishes to MQTT.
@@ -787,50 +818,51 @@ class PacketCaptureService(BaseServicePlugin):
             # If decode failed, create minimal packet_info with defaults (matches original script)
             if not packet_info:
                 if self.debug:
-                    self.logger.debug(f"Packet {self.packet_count} decode failed, using defaults (raw_hex: {raw_hex[:50]}...)")
+                    self.logger.debug(
+                        f"Packet {self.packet_count} decode failed, using defaults (raw_hex: {raw_hex[:50]}...)"
+                    )
                 # Try to calculate packet hash even if decode failed (extract payload_type from header if possible)
-                packet_hash = '0000000000000000'
+                packet_hash = "0000000000000000"
                 payload_type_value = None
                 try:
                     # Try to extract payload type from header for hash calculation
-                    byte_data = bytes.fromhex(raw_hex.replace('0x', ''))
+                    byte_data = bytes.fromhex(raw_hex.replace("0x", ""))
                     if len(byte_data) >= 1:
                         header = byte_data[0]
                         payload_type_value = (header >> 2) & 0x0F
-                        packet_hash = calculate_packet_hash(raw_hex.replace('0x', ''), payload_type_value)
+                        packet_hash = calculate_packet_hash(raw_hex.replace("0x", ""), payload_type_value)
                 except Exception:
                     pass  # Use default hash if calculation fails
 
                 # Create minimal packet info with defaults (matches original script's format_packet_data)
                 packet_info = {
-                    'route_type': 'UNKNOWN',
-                    'payload_type': 'UNKNOWN',
-                    'payload_type_value': payload_type_value or 0,
-                    'payload_version': 0,
-                    'path_len': 0,
-                    'path_byte_length': 0,
-                    'path_hex': '',
-                    'path': [],
-                    'payload_hex': raw_hex.replace('0x', ''),
-                    'payload_bytes': len(raw_hex.replace('0x', '')) // 2,
-                    'raw_hex': raw_hex.replace('0x', ''),
-                    'packet_hash': packet_hash,
-                    'has_transport_codes': False,
-                    'transport_codes': None
+                    "route_type": "UNKNOWN",
+                    "payload_type": "UNKNOWN",
+                    "payload_type_value": payload_type_value or 0,
+                    "payload_version": 0,
+                    "path_len": 0,
+                    "path_byte_length": 0,
+                    "path_hex": "",
+                    "path": [],
+                    "payload_hex": raw_hex.replace("0x", ""),
+                    "payload_bytes": len(raw_hex.replace("0x", "")) // 2,
+                    "raw_hex": raw_hex.replace("0x", ""),
+                    "packet_hash": packet_hash,
+                    "has_transport_codes": False,
+                    "transport_codes": None,
                 }
 
             # Format packet data to match original script's format
             formatted_packet = self._format_packet_data(raw_hex, packet_info, payload, metadata)
 
             skip_mqtt_unparseable = (
-                self.mqtt_skip_unparseable_packets
-                and formatted_packet.get('hash') == '0000000000000000'
+                self.mqtt_skip_unparseable_packets and formatted_packet.get("hash") == "0000000000000000"
             )
 
             skip_mqtt_invalid_advert_signature = False
-            if self.advert_require_valid_signature and packet_info.get('payload_type') == PayloadType.ADVERT.name:
+            if self.advert_require_valid_signature and packet_info.get("payload_type") == PayloadType.ADVERT.name:
                 try:
-                    mesh_payload = bytes.fromhex(packet_info.get('payload_hex', ''))
+                    mesh_payload = bytes.fromhex(packet_info.get("payload_hex", ""))
                     if not verify_meshcore_advert_ed25519(mesh_payload):
                         skip_mqtt_invalid_advert_signature = True
                 except Exception:
@@ -840,7 +872,7 @@ class PacketCaptureService(BaseServicePlugin):
 
             # Write to file
             if self.output_handle:
-                self.output_handle.write(json.dumps(formatted_packet, default=str) + '\n')
+                self.output_handle.write(json.dumps(formatted_packet, default=str) + "\n")
                 self.output_handle.flush()
 
             # Publish to MQTT if enabled
@@ -871,7 +903,9 @@ class PacketCaptureService(BaseServicePlugin):
                 action = "Skipping"
             else:
                 action = "Captured"
-            self.logger.debug(f"📦 {action} packet #{self.packet_count}: {formatted_packet['route']} type {formatted_packet['packet_type']}, {formatted_packet['len']} bytes, SNR: {formatted_packet['SNR']}, RSSI: {formatted_packet['RSSI']}, hash: {formatted_packet['hash']} (MQTT: {publish_metrics['succeeded']}/{publish_metrics['attempted']})")
+            self.logger.debug(
+                f"📦 {action} packet #{self.packet_count}: {formatted_packet['route']} type {formatted_packet['packet_type']}, {formatted_packet['len']} bytes, SNR: {formatted_packet['SNR']}, RSSI: {formatted_packet['RSSI']}, hash: {formatted_packet['hash']} (MQTT: {publish_metrics['succeeded']}/{publish_metrics['attempted']})"
+            )
 
             # Output full packet data structure in debug mode only (matches original script)
             if self.debug:
@@ -893,7 +927,7 @@ class PacketCaptureService(BaseServicePlugin):
         """
         try:
             # Remove 0x prefix if present
-            if raw_hex.startswith('0x'):
+            if raw_hex.startswith("0x"):
                 raw_hex = raw_hex[2:]
 
             byte_data = bytes.fromhex(raw_hex)
@@ -915,15 +949,17 @@ class PacketCaptureService(BaseServicePlugin):
             if has_transport and len(byte_data) >= 5:
                 transport_bytes = byte_data[1:5]
                 transport_codes = {
-                    'code1': int.from_bytes(transport_bytes[0:2], byteorder='little'),
-                    'code2': int.from_bytes(transport_bytes[2:4], byteorder='little'),
-                    'hex': transport_bytes.hex()
+                    "code1": int.from_bytes(transport_bytes[0:2], byteorder="little"),
+                    "code2": int.from_bytes(transport_bytes[2:4], byteorder="little"),
+                    "hex": transport_bytes.hex(),
                 }
                 offset = 5
 
             if len(byte_data) <= offset:
                 if self.debug:
-                    self.logger.debug(f"Packet too short after transport codes ({len(byte_data)} bytes, offset {offset}), cannot decode")
+                    self.logger.debug(
+                        f"Packet too short after transport codes ({len(byte_data)} bytes, offset {offset}), cannot decode"
+                    )
                 return None
 
             path_len_byte = byte_data[offset]
@@ -931,27 +967,27 @@ class PacketCaptureService(BaseServicePlugin):
             path_parts = decode_path_len_byte(path_len_byte)
             if path_parts is None:
                 if self.debug:
-                    self.logger.debug(
-                        "Packet invalid path_len encoding (not firmware-valid), cannot decode"
-                    )
+                    self.logger.debug("Packet invalid path_len encoding (not firmware-valid), cannot decode")
                 return None
             path_byte_length, bytes_per_hop = path_parts
 
             if len(byte_data) < offset + path_byte_length:
                 if self.debug:
-                    self.logger.debug(f"Packet too short for path ({len(byte_data)} bytes, need {offset + path_byte_length}), cannot decode")
+                    self.logger.debug(
+                        f"Packet too short for path ({len(byte_data)} bytes, need {offset + path_byte_length}), cannot decode"
+                    )
                 return None
 
             # Extract path
-            path_bytes = byte_data[offset:offset + path_byte_length]
+            path_bytes = byte_data[offset : offset + path_byte_length]
             offset += path_byte_length
 
             # Chunk path by bytes_per_hop from packet (1, 2, or 3); odd remainder → 1-byte chunks
             hex_chars = bytes_per_hop * 2
             path_hex = path_bytes.hex()
-            path_nodes = [path_hex[i:i + hex_chars].upper() for i in range(0, len(path_hex), hex_chars)]
+            path_nodes = [path_hex[i : i + hex_chars].upper() for i in range(0, len(path_hex), hex_chars)]
             if (len(path_hex) % hex_chars) != 0 or not path_nodes:
-                path_nodes = [path_hex[i:i + 2].upper() for i in range(0, len(path_hex), 2)]
+                path_nodes = [path_hex[i : i + 2].upper() for i in range(0, len(path_hex), 2)]
 
             # Remaining data is payload
             packet_payload = byte_data[offset:]
@@ -972,38 +1008,39 @@ class PacketCaptureService(BaseServicePlugin):
 
             # Build packet info (matching original format)
             packet_info = {
-                'header': f"0x{header:02x}",
-                'route_type': route_type.name,
-                'route_type_value': route_type.value,
-                'payload_type': payload_type.name,
-                'payload_type_value': payload_type.value,
-                'payload_version': payload_version.value,
-                'path_len': len(path_nodes),
-                'path_byte_length': path_byte_length,
-                'bytes_per_hop': bytes_per_hop,
-                'path_hex': path_hex,
-                'path': path_nodes,  # For TRACE, RF path is SNR×4 per hop — replaced below
-                'payload_hex': packet_payload.hex(),
-                'payload_bytes': len(packet_payload),
-                'raw_hex': raw_hex,
-                'packet_hash': packet_hash,
-                'has_transport_codes': has_transport,
-                'transport_codes': transport_codes
+                "header": f"0x{header:02x}",
+                "route_type": route_type.name,
+                "route_type_value": route_type.value,
+                "payload_type": payload_type.name,
+                "payload_type_value": payload_type.value,
+                "payload_version": payload_version.value,
+                "path_len": len(path_nodes),
+                "path_byte_length": path_byte_length,
+                "bytes_per_hop": bytes_per_hop,
+                "path_hex": path_hex,
+                "path": path_nodes,  # For TRACE, RF path is SNR×4 per hop — replaced below
+                "payload_hex": packet_payload.hex(),
+                "payload_bytes": len(packet_payload),
+                "raw_hex": raw_hex,
+                "packet_hash": packet_hash,
+                "has_transport_codes": has_transport,
+                "transport_codes": transport_codes,
             }
 
             # TRACE: RF path bytes are SNR samples; commanded route is in payload[9:]
             if payload_type == PayloadType.TRACE:
-                packet_info['trace_snr_path_hex'] = path_hex.upper()
+                packet_info["trace_snr_path_hex"] = path_hex.upper()
                 trace_route = parse_trace_payload_route_hashes(packet_payload)
                 if trace_route:
-                    packet_info['path'] = trace_route
-                    packet_info['path_len'] = len(trace_route)
+                    packet_info["path"] = trace_route
+                    packet_info["path_len"] = len(trace_route)
 
             return packet_info
 
         except Exception as e:
             self.logger.debug(f"Error decoding packet: {e} (raw_hex: {raw_hex[:50]}...)")
             import traceback
+
             if self.debug:
                 self.logger.debug(f"Decode error traceback: {traceback.format_exc()}")
             return None
@@ -1015,24 +1052,24 @@ class PacketCaptureService(BaseServicePlugin):
             str: The name of the bot/device.
         """
         # Try to get name from device first
-        if self.meshcore and hasattr(self.meshcore, 'self_info'):
+        if self.meshcore and hasattr(self.meshcore, "self_info"):
             try:
                 self_info = self.meshcore.self_info
                 if isinstance(self_info, dict):
-                    device_name = self_info.get('name') or self_info.get('adv_name')
+                    device_name = self_info.get("name") or self_info.get("adv_name")
                     if device_name:
                         return device_name
-                elif hasattr(self_info, 'name'):
+                elif hasattr(self_info, "name"):
                     if self_info.name:
                         return self_info.name
-                elif hasattr(self_info, 'adv_name'):
+                elif hasattr(self_info, "adv_name"):
                     if self_info.adv_name:
                         return self_info.adv_name
             except Exception as e:
                 self.logger.debug(f"Could not get name from device: {e}")
 
         # Fallback to config
-        bot_name = self.bot.config.get('Bot', 'bot_name', fallback='MeshCoreBot')
+        bot_name = self.bot.config.get("Bot", "bot_name", fallback="MeshCoreBot")
         return bot_name
 
     def _require_mqtt(self) -> bool:
@@ -1042,10 +1079,7 @@ class PacketCaptureService(BaseServicePlugin):
             bool: True if MQTT requirements are met, False otherwise.
         """
         if mqtt is None:
-            self.logger.warning(
-                "MQTT support not available. Install paho-mqtt: "
-                "pip install paho-mqtt"
-            )
+            self.logger.warning("MQTT support not available. Install paho-mqtt: pip install paho-mqtt")
             return False
         return True
 
@@ -1061,27 +1095,24 @@ class PacketCaptureService(BaseServicePlugin):
         bot_name = self._get_bot_name()
 
         for broker_config in self.mqtt_brokers:
-            if not broker_config.get('enabled', True):
+            if not broker_config.get("enabled", True):
                 continue
 
             try:
                 # Use configured client_id, or generate from bot name
-                client_id = broker_config.get('client_id')
+                client_id = broker_config.get("client_id")
                 if not client_id:
                     # Sanitize bot name for MQTT client ID (alphanumeric and hyphens only)
-                    safe_name = ''.join(c if c.isalnum() or c == '-' else '-' for c in bot_name)
+                    safe_name = "".join(c if c.isalnum() or c == "-" else "-" for c in bot_name)
                     client_id = f"{safe_name}-packet-capture-{os.getpid()}"
 
                 # Create client based on transport type
-                transport = broker_config.get('transport', 'tcp').lower()
-                if transport == 'websockets':
+                transport = broker_config.get("transport", "tcp").lower()
+                if transport == "websockets":
                     try:
-                        client = mqtt.Client(
-                            client_id=client_id,
-                            transport='websockets'
-                        )
+                        client = mqtt.Client(client_id=client_id, transport="websockets")
                         # Set WebSocket path (must be done before connect)
-                        ws_path = broker_config.get('websocket_path', '/mqtt')
+                        ws_path = broker_config.get("websocket_path", "/mqtt")
                         client.ws_set_options(path=ws_path, headers=None)
                     except Exception as e:
                         self.logger.error(f"WebSockets transport not available: {e}")
@@ -1093,9 +1124,10 @@ class PacketCaptureService(BaseServicePlugin):
                 client.reconnect_delay_set(min_delay=1, max_delay=120)
 
                 # Set TLS if enabled
-                if broker_config.get('use_tls', False):
+                if broker_config.get("use_tls", False):
                     try:
                         import ssl
+
                         # For WebSockets with TLS (WSS), we need to set TLS on the client
                         # The TLS handshake happens during the WebSocket upgrade
                         client.tls_set(cert_reqs=ssl.CERT_NONE)  # Allow self-signed certs
@@ -1105,22 +1137,22 @@ class PacketCaptureService(BaseServicePlugin):
                         self.logger.warning(f"TLS setup failed for {broker_config['host']}: {e}")
 
                 # Set username/password if provided
-                username = broker_config.get('username')
-                password = broker_config.get('password')
+                username = broker_config.get("username")
+                password = broker_config.get("password")
 
-                if broker_config.get('use_auth_token'):
+                if broker_config.get("use_auth_token"):
                     # Use auth token with audience if specified
-                    token_audience = broker_config.get('token_audience') or broker_config['host']
+                    token_audience = broker_config.get("token_audience") or broker_config["host"]
 
                     # Get device's public key (from self_info) - this is what we use for username and JWT publicKey
                     # The owner_public_key is ONLY for the 'owner' field in the JWT payload
                     device_public_key_hex = None
-                    if self.meshcore and hasattr(self.meshcore, 'self_info'):
+                    if self.meshcore and hasattr(self.meshcore, "self_info"):
                         try:
                             self_info = self.meshcore.self_info
                             if isinstance(self_info, dict):
-                                device_public_key_hex = self_info.get('public_key', '')
-                            elif hasattr(self_info, 'public_key'):
+                                device_public_key_hex = self_info.get("public_key", "")
+                            elif hasattr(self_info, "public_key"):
                                 device_public_key_hex = self_info.public_key
 
                             # Convert to hex string if bytes
@@ -1132,13 +1164,13 @@ class PacketCaptureService(BaseServicePlugin):
                             self.logger.debug(f"Could not get public key from device: {e}")
 
                     if not device_public_key_hex:
-                        self.logger.warning(f"No device public key available for auth token (broker: {broker_config['host']})")
+                        self.logger.warning(
+                            f"No device public key available for auth token (broker: {broker_config['host']})"
+                        )
                         continue
 
                     # Create auth token (tries on-device signing first if available)
-                    use_device = (self.auth_token_method == 'device' and
-                                 self.meshcore and
-                                 self.meshcore.is_connected)
+                    use_device = self.auth_token_method == "device" and self.meshcore and self.meshcore.is_connected
 
                     # For Python signing, we still need meshcore_instance to fetch the private key
                     # The use_device flag only controls whether we try on-device signing first
@@ -1149,21 +1181,26 @@ class PacketCaptureService(BaseServicePlugin):
                         if not username:
                             username = f"v1_{device_public_key_hex.upper()}"
 
+                        iat, exp = self._auth_token_iat_exp(broker_config)
+                        ttl_used = exp - iat
                         token = await create_auth_token_async(
                             meshcore_instance=meshcore_for_key_fetch,
                             public_key_hex=device_public_key_hex,  # Device's actual public key (for JWT publicKey field)
                             private_key_hex=self.private_key_hex,
                             iata=self.global_iata,
+                            timestamp=iat,
                             audience=token_audience,
+                            exp=exp,
                             owner_public_key=self.owner_public_key,  # Owner's key (only for 'owner' field in JWT)
                             owner_email=self.owner_email,
-                            use_device=use_device
+                            use_device=use_device,
                         )
                         if token:
                             password = token
+                            ttl_phrase = self._jwt_ttl_log_phrase(ttl_used)
                             self.logger.debug(
                                 f"Created auth token for {broker_config['host']} "
-                                f"(username: {username}, valid for 24 hours) "
+                                f"(username: {username}, TTL {ttl_phrase}) "
                                 f"using {'device' if use_device else 'Python'} signing"
                             )
                         else:
@@ -1178,22 +1215,22 @@ class PacketCaptureService(BaseServicePlugin):
                 def on_connect(client, userdata, flags, rc, properties=None):
                     cfg = None
                     for mqtt_info in self.mqtt_clients:
-                        if mqtt_info['client'] == client:
-                            cfg = mqtt_info['config']
+                        if mqtt_info["client"] == client:
+                            cfg = mqtt_info["config"]
                             break
                     if cfg is None:
                         return
-                    tr = cfg.get('transport', 'tcp').lower()
-                    host, port = cfg['host'], cfg['port']
+                    tr = cfg.get("transport", "tcp").lower()
+                    host, port = cfg["host"], cfg["port"]
                     if rc == 0:
                         self.logger.info(f"✓ Connected to MQTT broker: {host}:{port} ({tr})")
                         # Track connection per broker
                         for mqtt_info in self.mqtt_clients:
-                            if mqtt_info['client'] == client:
-                                mqtt_info['connected'] = True
+                            if mqtt_info["client"] == client:
+                                mqtt_info["connected"] = True
                                 break
                         # Set global connected flag if any broker is connected
-                        self.mqtt_connected = any(m.get('connected', False) for m in self.mqtt_clients)
+                        self.mqtt_connected = any(m.get("connected", False) for m in self.mqtt_clients)
                     else:
                         # MQTT error codes: 0=success, 1=protocol, 2=client, 3=network, 4=transport, 5=auth
                         error_messages = {
@@ -1201,42 +1238,40 @@ class PacketCaptureService(BaseServicePlugin):
                             2: "client identifier rejected",
                             3: "server unavailable",
                             4: "bad username or password",
-                            5: "not authorized"
+                            5: "not authorized",
                         }
                         error_msg = error_messages.get(rc, f"unknown error ({rc})")
-                        self.logger.error(
-                            f"✗ Failed to connect to MQTT broker {host}: {rc} ({error_msg})"
-                        )
+                        self.logger.error(f"✗ Failed to connect to MQTT broker {host}: {rc} ({error_msg})")
                         # Mark this broker as disconnected
                         for mqtt_info in self.mqtt_clients:
-                            if mqtt_info['client'] == client:
-                                mqtt_info['connected'] = False
+                            if mqtt_info["client"] == client:
+                                mqtt_info["connected"] = False
                                 break
                         # Update global flag
-                        self.mqtt_connected = any(m.get('connected', False) for m in self.mqtt_clients)
+                        self.mqtt_connected = any(m.get("connected", False) for m in self.mqtt_clients)
 
                 def on_disconnect(client, userdata, rc, properties=None):
                     # Mark this broker as disconnected
                     for mqtt_info in self.mqtt_clients:
-                        if mqtt_info['client'] == client:
-                            mqtt_info['connected'] = False
-                            cfg = mqtt_info['config']
-                            host = cfg['host']
+                        if mqtt_info["client"] == client:
+                            mqtt_info["connected"] = False
+                            cfg = mqtt_info["config"]
+                            host = cfg["host"]
                             if rc != 0:
                                 self.logger.warning(f"Disconnected from MQTT broker {host} (rc={rc})")
                             else:
                                 self.logger.debug(f"Disconnected from MQTT broker {host}")
                             break
                     # Update global flag
-                    self.mqtt_connected = any(m.get('connected', False) for m in self.mqtt_clients)
+                    self.mqtt_connected = any(m.get("connected", False) for m in self.mqtt_clients)
 
                 client.on_connect = on_connect
                 client.on_disconnect = on_disconnect
 
                 # Connect
                 try:
-                    host = broker_config['host']
-                    port = broker_config['port']
+                    host = broker_config["host"]
+                    port = broker_config["port"]
 
                     # Validate hostname (basic check)
                     if not host or not host.strip():
@@ -1246,6 +1281,7 @@ class PacketCaptureService(BaseServicePlugin):
                     # Try to resolve hostname first (for better error messages)
                     try:
                         import socket
+
                         socket.gethostbyname(host)
                     except socket.gaierror as dns_error:
                         # Only log DNS errors at debug level, not as errors
@@ -1257,16 +1293,20 @@ class PacketCaptureService(BaseServicePlugin):
                             self.logger.debug(f"Hostname resolution check for '{host}': {resolve_error}")
 
                     # Add client to list BEFORE starting the loop, so callbacks can find it
-                    self.mqtt_clients.append({
-                        'client': client,
-                        'config': broker_config,
-                        'connected': False  # Track connection status per broker
-                    })
+                    self.mqtt_clients.append(
+                        {
+                            "client": client,
+                            "config": broker_config,
+                            "connected": False,  # Track connection status per broker
+                        }
+                    )
 
-                    if transport == 'websockets':
+                    if transport == "websockets":
                         # WebSocket path already set via ws_set_options above
-                        ws_path = broker_config.get('websocket_path', '/mqtt')
-                        self.logger.debug(f"Connecting to MQTT broker {host}:{port} via WebSockets (path: {ws_path}, TLS: {broker_config.get('use_tls', False)})")
+                        ws_path = broker_config.get("websocket_path", "/mqtt")
+                        self.logger.debug(
+                            f"Connecting to MQTT broker {host}:{port} via WebSockets (path: {ws_path}, TLS: {broker_config.get('use_tls', False)})"
+                        )
                         # For WebSockets, connect without path parameter (path set via ws_set_options)
                         # Run connect in executor to avoid blocking the event loop
                         loop = asyncio.get_event_loop()
@@ -1276,7 +1316,9 @@ class PacketCaptureService(BaseServicePlugin):
                             # Connection failed, but don't block - let loop_start handle retries
                             self.logger.debug(f"Initial connect() call failed (non-blocking): {connect_error}")
                     else:
-                        self.logger.debug(f"Connecting to MQTT broker {host}:{port} via TCP (TLS: {broker_config.get('use_tls', False)})")
+                        self.logger.debug(
+                            f"Connecting to MQTT broker {host}:{port} via TCP (TLS: {broker_config.get('use_tls', False)})"
+                        )
                         # Run connect in executor to avoid blocking the event loop
                         loop = asyncio.get_event_loop()
                         try:
@@ -1299,12 +1341,18 @@ class PacketCaptureService(BaseServicePlugin):
                         if self.debug:
                             self.logger.debug(f"DNS/Connection error for '{broker_config['host']}': {error_msg}")
                         else:
-                            self.logger.warning(f"Could not connect to MQTT broker '{broker_config['host']}' (check network/DNS)")
+                            self.logger.warning(
+                                f"Could not connect to MQTT broker '{broker_config['host']}' (check network/DNS)"
+                            )
                     elif "Connection refused" in error_msg:
                         if self.debug:
-                            self.logger.debug(f"Connection refused by '{broker_config['host']}:{broker_config['port']}': {error_msg}")
+                            self.logger.debug(
+                                f"Connection refused by '{broker_config['host']}:{broker_config['port']}': {error_msg}"
+                            )
                         else:
-                            self.logger.warning(f"Connection refused by MQTT broker '{broker_config['host']}:{broker_config['port']}'")
+                            self.logger.warning(
+                                f"Connection refused by MQTT broker '{broker_config['host']}:{broker_config['port']}'"
+                            )
                     else:
                         if self.debug:
                             self.logger.debug(f"MQTT connection error for '{broker_config['host']}': {error_msg}")
@@ -1318,7 +1366,7 @@ class PacketCaptureService(BaseServicePlugin):
         await asyncio.sleep(2)
 
         # Log summary and publish initial status (matches original script)
-        connected_count = sum(1 for m in self.mqtt_clients if m.get('connected', False))
+        connected_count = sum(1 for m in self.mqtt_clients if m.get("connected", False))
         if connected_count > 0:
             self.logger.info(f"Connected to {connected_count} MQTT broker(s)")
             # Publish initial status with firmware version now that MQTT is connected (matches original script)
@@ -1327,7 +1375,7 @@ class PacketCaptureService(BaseServicePlugin):
         else:
             self.logger.warning("MQTT enabled but no brokers connected")
 
-    def _resolve_topic_template(self, template: str, packet_type: str = 'packet') -> str | None:
+    def _resolve_topic_template(self, template: str, packet_type: str = "packet") -> str | None:
         """Resolve topic template with placeholders.
 
         Args:
@@ -1343,12 +1391,12 @@ class PacketCaptureService(BaseServicePlugin):
         # Get device's public key (NOT owner's key - owner key is only for JWT 'owner' field)
         # This matches the original script which uses self.device_public_key from self_info
         device_public_key = None
-        if self.meshcore and hasattr(self.meshcore, 'self_info'):
+        if self.meshcore and hasattr(self.meshcore, "self_info"):
             try:
                 self_info = self.meshcore.self_info
                 if isinstance(self_info, dict):
-                    device_public_key = self_info.get('public_key', '')
-                elif hasattr(self_info, 'public_key'):
+                    device_public_key = self_info.get("public_key", "")
+                elif hasattr(self_info, "public_key"):
                     device_public_key = self_info.public_key
 
                 # Convert to hex string if bytes
@@ -1361,13 +1409,18 @@ class PacketCaptureService(BaseServicePlugin):
 
         # Normalize to uppercase (remove 0x prefix if present)
         if device_public_key:
-            device_public_key = device_public_key.replace('0x', '').replace(' ', '').upper()
+            device_public_key = device_public_key.replace("0x", "").replace(" ", "").upper()
 
         # Replace placeholders (matches original script's resolve_topic_template)
-        topic = template.replace('{IATA}', self.global_iata.upper())
-        topic = topic.replace('{iata}', self.global_iata.lower())
-        topic = topic.replace('{PUBLIC_KEY}', device_public_key if device_public_key and device_public_key != 'Unknown' else 'DEVICE')
-        topic = topic.replace('{public_key}', (device_public_key if device_public_key and device_public_key != 'Unknown' else 'DEVICE').lower())
+        topic = template.replace("{IATA}", self.global_iata.upper())
+        topic = topic.replace("{iata}", self.global_iata.lower())
+        topic = topic.replace(
+            "{PUBLIC_KEY}", device_public_key if device_public_key and device_public_key != "Unknown" else "DEVICE"
+        )
+        topic = topic.replace(
+            "{public_key}",
+            (device_public_key if device_public_key and device_public_key != "Unknown" else "DEVICE").lower(),
+        )
 
         return topic
 
@@ -1393,21 +1446,23 @@ class PacketCaptureService(BaseServicePlugin):
             self.logger.debug("No MQTT clients configured, skipping publish")
             return metrics
 
-        connected_count = sum(1 for m in self.mqtt_clients if m.get('connected', False))
+        connected_count = sum(1 for m in self.mqtt_clients if m.get("connected", False))
         self.logger.debug(f"Publishing packet to MQTT ({connected_count}/{len(self.mqtt_clients)} brokers connected)")
 
         for mqtt_client_info in self.mqtt_clients:
             # Only publish to connected brokers
-            if not mqtt_client_info.get('connected', False):
-                self.logger.debug(f"Skipping MQTT broker {mqtt_client_info['config'].get('host', 'unknown')} (not connected)")
+            if not mqtt_client_info.get("connected", False):
+                self.logger.debug(
+                    f"Skipping MQTT broker {mqtt_client_info['config'].get('host', 'unknown')} (not connected)"
+                )
                 continue
             try:
-                client = mqtt_client_info['client']
-                config = mqtt_client_info['config']
+                client = mqtt_client_info["client"]
+                config = mqtt_client_info["config"]
 
                 # Per-broker packet type filter: if set, only upload listed types (e.g. 2,4 = TXT_MSG, ADVERT)
-                upload_types = config.get('upload_packet_types')
-                if upload_types is not None and packet_info.get('packet_type', '') not in upload_types:
+                upload_types = config.get("upload_packet_types")
+                if upload_types is not None and packet_info.get("packet_type", "") not in upload_types:
                     metrics["skipped_by_filter"] = True
                     self.logger.debug(
                         f"Skipping MQTT broker {config.get('host', 'unknown')} (packet type {packet_info.get('packet_type')} not in {sorted(upload_types)})"
@@ -1416,12 +1471,12 @@ class PacketCaptureService(BaseServicePlugin):
 
                 # Determine topic
                 topic = None
-                if config.get('topic_packets'):
-                    topic = self._resolve_topic_template(config['topic_packets'], 'packet')
-                elif config.get('topic_prefix'):
+                if config.get("topic_packets"):
+                    topic = self._resolve_topic_template(config["topic_packets"], "packet")
+                elif config.get("topic_prefix"):
                     topic = f"{config['topic_prefix']}/packet"
                 else:
-                    topic = 'meshcore/packets/packet'
+                    topic = "meshcore/packets/packet"
 
                 if not topic:
                     continue
@@ -1440,7 +1495,9 @@ class PacketCaptureService(BaseServicePlugin):
                     metrics["succeeded"] += 1
                     self.logger.debug(f"Published packet to MQTT topic '{topic}' on {config['host']} (qos=0)")
                 else:
-                    self.logger.warning(f"Failed to publish packet to MQTT topic '{topic}' on {config['host']}: {result.rc} ({mqtt.error_string(result.rc)})")
+                    self.logger.warning(
+                        f"Failed to publish packet to MQTT topic '{topic}' on {config['host']}: {result.rc} ({mqtt.error_string(result.rc)})"
+                    )
 
             except Exception as e:
                 self.logger.error(f"Error publishing packet to MQTT on {config.get('host', 'unknown')}: {e}")
@@ -1456,7 +1513,7 @@ class PacketCaptureService(BaseServicePlugin):
     async def start_background_tasks(self) -> None:
         """Start background tasks.
 
-        Initializes scheduler for stats refresh, JWT renewal, health checks,
+        Initializes scheduler for stats refresh, per-broker JWT renewal, health checks,
         and MQTT reconnection monitor.
         """
         # Stats refresh scheduler (matches original script)
@@ -1464,10 +1521,12 @@ class PacketCaptureService(BaseServicePlugin):
             self.stats_update_task = asyncio.create_task(self.stats_refresh_scheduler())
             self.background_tasks.append(self.stats_update_task)
 
-        # JWT renewal scheduler
-        if self.jwt_renewal_interval > 0:
-            task = asyncio.create_task(self.jwt_renewal_scheduler())
-            self.background_tasks.append(task)
+        # Per-broker JWT renewal (only brokers with use_auth_token and jwt_renewal_interval > 0)
+        for mqtt_client_info in self.mqtt_clients:
+            cfg = mqtt_client_info["config"]
+            if cfg.get("use_auth_token") and cfg.get("jwt_renewal_interval", 0) > 0:
+                task = asyncio.create_task(self.jwt_renewal_scheduler_for_client(mqtt_client_info))
+                self.background_tasks.append(task)
 
         # Health check
         if self.health_check_interval > 0:
@@ -1491,7 +1550,7 @@ class PacketCaptureService(BaseServicePlugin):
             try:
                 # Only fetch stats when we're about to publish status
                 if self.mqtt_enabled:
-                    connected_count = sum(1 for m in self.mqtt_clients if m.get('connected', False))
+                    connected_count = sum(1 for m in self.mqtt_clients if m.get("connected", False))
                     if connected_count > 0:
                         await self.publish_status("online", refresh_stats=True)
             except asyncio.CancelledError:
@@ -1568,16 +1627,16 @@ class PacketCaptureService(BaseServicePlugin):
                 self.logger.debug(f"Device query payload: {payload}")
 
                 # Check firmware version format
-                fw_ver = payload.get('fw ver', 0)
+                fw_ver = payload.get("fw ver", 0)
                 self.logger.debug(f"Firmware version number: {fw_ver}")
 
                 if fw_ver >= 3:
                     # For newer firmware versions (v3+)
-                    model = payload.get('model', 'Unknown')
-                    version = payload.get('ver', 'Unknown')
-                    build_date = payload.get('fw_build', 'Unknown')
+                    model = payload.get("model", "Unknown")
+                    version = payload.get("ver", "Unknown")
+                    build_date = payload.get("fw_build", "Unknown")
                     # Remove 'v' prefix from version if it already has one
-                    if version.startswith('v'):
+                    if version.startswith("v"):
                         version = version[1:]
                     version_str = f"v{version} (Build: {build_date})"
                     self.logger.debug(f"New firmware format - Model: {model}, Version: {version_str}")
@@ -1710,12 +1769,12 @@ class PacketCaptureService(BaseServicePlugin):
 
         # Get device public key for origin_id
         device_public_key = None
-        if self.meshcore and hasattr(self.meshcore, 'self_info'):
+        if self.meshcore and hasattr(self.meshcore, "self_info"):
             try:
                 self_info = self.meshcore.self_info
                 if isinstance(self_info, dict):
-                    device_public_key = self_info.get('public_key', '')
-                elif hasattr(self_info, 'public_key'):
+                    device_public_key = self_info.get("public_key", "")
+                elif hasattr(self_info, "public_key"):
                     device_public_key = self_info.public_key
 
                 # Convert to hex string if bytes
@@ -1728,18 +1787,28 @@ class PacketCaptureService(BaseServicePlugin):
 
         # Normalize origin_id to uppercase
         if device_public_key:
-            device_public_key = device_public_key.replace('0x', '').replace(' ', '').upper()
+            device_public_key = device_public_key.replace("0x", "").replace(" ", "").upper()
         else:
-            device_public_key = 'DEVICE'
+            device_public_key = "DEVICE"
 
         # Get radio info if available
-        if not self.radio_info and self.meshcore and hasattr(self.meshcore, 'self_info'):
+        if not self.radio_info and self.meshcore and hasattr(self.meshcore, "self_info"):
             try:
                 self_info = self.meshcore.self_info
-                radio_freq = self_info.get('radio_freq', 0) if isinstance(self_info, dict) else getattr(self_info, 'radio_freq', 0)
-                radio_bw = self_info.get('radio_bw', 0) if isinstance(self_info, dict) else getattr(self_info, 'radio_bw', 0)
-                radio_sf = self_info.get('radio_sf', 0) if isinstance(self_info, dict) else getattr(self_info, 'radio_sf', 0)
-                radio_cr = self_info.get('radio_cr', 0) if isinstance(self_info, dict) else getattr(self_info, 'radio_cr', 0)
+                radio_freq = (
+                    self_info.get("radio_freq", 0)
+                    if isinstance(self_info, dict)
+                    else getattr(self_info, "radio_freq", 0)
+                )
+                radio_bw = (
+                    self_info.get("radio_bw", 0) if isinstance(self_info, dict) else getattr(self_info, "radio_bw", 0)
+                )
+                radio_sf = (
+                    self_info.get("radio_sf", 0) if isinstance(self_info, dict) else getattr(self_info, "radio_sf", 0)
+                )
+                radio_cr = (
+                    self_info.get("radio_cr", 0) if isinstance(self_info, dict) else getattr(self_info, "radio_cr", 0)
+                )
                 self.radio_info = f"{radio_freq},{radio_bw},{radio_sf},{radio_cr}"
             except Exception:
                 pass
@@ -1749,17 +1818,14 @@ class PacketCaptureService(BaseServicePlugin):
             "timestamp": datetime.now().isoformat(),
             "origin": device_name,
             "origin_id": device_public_key,
-            "model": firmware_info.get('model', 'unknown'),
-            "firmware_version": firmware_info.get('version', 'unknown'),
+            "model": firmware_info.get("model", "unknown"),
+            "firmware_version": firmware_info.get("version", "unknown"),
             "radio": self.radio_info or "unknown",
-            "client_version": self._load_client_version()
+            "client_version": self._load_client_version(),
         }
 
         # Attach stats (online status only) if supported and enabled
-        if (
-            status.lower() == "online"
-            and self.stats_status_enabled
-        ):
+        if status.lower() == "online" and self.stats_status_enabled:
             stats_payload = None
             if refresh_stats:
                 # Always force refresh stats right before publishing to ensure fresh data
@@ -1777,20 +1843,20 @@ class PacketCaptureService(BaseServicePlugin):
         # Publish status to all connected brokers
         for mqtt_client_info in self.mqtt_clients:
             # Only publish to connected brokers
-            if not mqtt_client_info.get('connected', False):
+            if not mqtt_client_info.get("connected", False):
                 continue
             try:
-                client = mqtt_client_info['client']
-                config = mqtt_client_info['config']
+                client = mqtt_client_info["client"]
+                config = mqtt_client_info["config"]
 
                 # Determine topic
                 topic = None
-                if config.get('topic_status'):
-                    topic = self._resolve_topic_template(config['topic_status'], 'status')
-                elif config.get('topic_prefix'):
+                if config.get("topic_status"):
+                    topic = self._resolve_topic_template(config["topic_status"], "status")
+                elif config.get("topic_prefix"):
                     topic = f"{config['topic_prefix']}/status"
                 else:
-                    topic = 'meshcore/status'
+                    topic = "meshcore/status"
 
                 if not topic:
                     continue
@@ -1808,93 +1874,90 @@ class PacketCaptureService(BaseServicePlugin):
             except Exception as e:
                 self.logger.error(f"Error publishing status to MQTT: {e}")
 
-    async def jwt_renewal_scheduler(self) -> None:
-        """Background task to proactively renew JWT tokens before expiration.
+    async def _renew_mqtt_auth_token(self, mqtt_client_info: dict[str, Any]) -> None:
+        """Mint a new auth token and apply it to one MQTT client (per-broker TTL)."""
+        config = mqtt_client_info["config"]
+        client = mqtt_client_info["client"]
+        broker_host = config.get("host", "unknown")
 
-        Renews auth tokens for all MQTT brokers that use token authentication.
-        Runs every jwt_renewal_interval seconds (default: 12 hours).
-        Tokens are valid for 24 hours, so this provides a 12-hour buffer.
-        """
-        if self.jwt_renewal_interval <= 0:
+        if not config.get("use_auth_token"):
+            return
+
+        self.logger.debug(f"Renewing auth token for MQTT broker {broker_host}...")
+
+        device_public_key_hex = None
+        if self.meshcore and hasattr(self.meshcore, "self_info"):
+            try:
+                self_info = self.meshcore.self_info
+                if isinstance(self_info, dict):
+                    device_public_key_hex = self_info.get("public_key", "")
+                elif hasattr(self_info, "public_key"):
+                    device_public_key_hex = self_info.public_key
+
+                if isinstance(device_public_key_hex, bytes):
+                    device_public_key_hex = device_public_key_hex.hex()
+                elif isinstance(device_public_key_hex, bytearray):
+                    device_public_key_hex = bytes(device_public_key_hex).hex()
+            except Exception as e:
+                self.logger.debug(f"Could not get public key from device: {e}")
+
+        if not device_public_key_hex:
+            self.logger.warning(f"No device public key available for token renewal (broker: {broker_host})")
+            return
+
+        token_audience = config.get("token_audience") or broker_host
+        username = f"v1_{device_public_key_hex.upper()}"
+
+        use_device = self.auth_token_method == "device" and self.meshcore and self.meshcore.is_connected
+        meshcore_for_key_fetch = self.meshcore if self.meshcore and self.meshcore.is_connected else None
+
+        try:
+            iat, exp = self._auth_token_iat_exp(config)
+            ttl_used = exp - iat
+            token = await create_auth_token_async(
+                meshcore_instance=meshcore_for_key_fetch,
+                public_key_hex=device_public_key_hex,
+                private_key_hex=self.private_key_hex,
+                iata=self.global_iata,
+                timestamp=iat,
+                audience=token_audience,
+                exp=exp,
+                owner_public_key=self.owner_public_key,
+                owner_email=self.owner_email,
+                use_device=use_device,
+            )
+
+            if token:
+                client.username_pw_set(username, token)
+                ttl_phrase = self._jwt_ttl_log_phrase(ttl_used)
+                self.logger.info(f"✓ Renewed auth token for MQTT broker {broker_host} (TTL {ttl_phrase})")
+            else:
+                self.logger.warning(f"Failed to renew auth token for MQTT broker {broker_host}")
+        except Exception as e:
+            self.logger.error(f"Error renewing token for MQTT broker {broker_host}: {e}")
+
+    async def jwt_renewal_scheduler_for_client(self, mqtt_client_info: dict[str, Any]) -> None:
+        """Background task: renew JWT on one broker every config jwt_renewal_interval seconds."""
+        config = mqtt_client_info["config"]
+        interval = int(config.get("jwt_renewal_interval", 0))
+        if interval <= 0:
             return
 
         while not self.should_exit:
             try:
-                await asyncio.sleep(self.jwt_renewal_interval)
-
+                if await self._wait_with_shutdown(float(interval)):
+                    break
                 if self.should_exit:
                     break
-
-                # Renew tokens for all MQTT brokers that use auth tokens
-                for mqtt_client_info in self.mqtt_clients:
-                    config = mqtt_client_info['config']
-                    client = mqtt_client_info['client']
-
-                    # Only renew for brokers that use auth tokens
-                    if not config.get('use_auth_token'):
-                        continue
-
-                    try:
-                        broker_host = config.get('host', 'unknown')
-                        self.logger.debug(f"Renewing auth token for MQTT broker {broker_host}...")
-
-                        # Get device's public key
-                        device_public_key_hex = None
-                        if self.meshcore and hasattr(self.meshcore, 'self_info'):
-                            try:
-                                self_info = self.meshcore.self_info
-                                if isinstance(self_info, dict):
-                                    device_public_key_hex = self_info.get('public_key', '')
-                                elif hasattr(self_info, 'public_key'):
-                                    device_public_key_hex = self_info.public_key
-
-                                # Convert to hex string if bytes
-                                if isinstance(device_public_key_hex, bytes):
-                                    device_public_key_hex = device_public_key_hex.hex()
-                                elif isinstance(device_public_key_hex, bytearray):
-                                    device_public_key_hex = bytes(device_public_key_hex).hex()
-                            except Exception as e:
-                                self.logger.debug(f"Could not get public key from device: {e}")
-
-                        if not device_public_key_hex:
-                            self.logger.warning(f"No device public key available for token renewal (broker: {broker_host})")
-                            continue
-
-                        # Create new auth token
-                        token_audience = config.get('token_audience') or broker_host
-                        username = f"v1_{device_public_key_hex.upper()}"
-
-                        use_device = (self.auth_token_method == 'device' and
-                                     self.meshcore and
-                                     self.meshcore.is_connected)
-                        meshcore_for_key_fetch = self.meshcore if self.meshcore and self.meshcore.is_connected else None
-
-                        token = await create_auth_token_async(
-                            meshcore_instance=meshcore_for_key_fetch,
-                            public_key_hex=device_public_key_hex,
-                            private_key_hex=self.private_key_hex,
-                            iata=self.global_iata,
-                            audience=token_audience,
-                            owner_public_key=self.owner_public_key,
-                            owner_email=self.owner_email,
-                            use_device=use_device
-                        )
-
-                        if token:
-                            # Update client credentials with new token
-                            client.username_pw_set(username, token)
-                            self.logger.info(f"✓ Renewed auth token for MQTT broker {broker_host} (valid for 24 hours)")
-                        else:
-                            self.logger.warning(f"Failed to renew auth token for MQTT broker {broker_host}")
-
-                    except Exception as e:
-                        self.logger.error(f"Error renewing token for MQTT broker {config.get('host', 'unknown')}: {e}")
-
+                if not config.get("use_auth_token"):
+                    continue
+                await self._renew_mqtt_auth_token(mqtt_client_info)
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                self.logger.error(f"Error in JWT renewal scheduler: {e}")
-                await asyncio.sleep(60)
+                self.logger.error(f"Error in JWT renewal scheduler ({config.get('host', 'unknown')}): {e}")
+                if await self._wait_with_shutdown(60):
+                    break
 
     async def health_check_loop(self) -> None:
         """Background task for health checks.
@@ -1942,9 +2005,9 @@ class PacketCaptureService(BaseServicePlugin):
 
                 # Check each broker's connection status
                 for mqtt_client_info in self.mqtt_clients:
-                    client = mqtt_client_info['client']
-                    config = mqtt_client_info['config']
-                    broker_host = config.get('host', 'unknown')
+                    client = mqtt_client_info["client"]
+                    config = mqtt_client_info["config"]
+                    broker_host = config.get("host", "unknown")
 
                     # Check if client is connected
                     if not client.is_connected():
@@ -1953,15 +2016,15 @@ class PacketCaptureService(BaseServicePlugin):
                             self.logger.info(f"MQTT broker {broker_host} is disconnected, attempting reconnection...")
 
                             # If using auth tokens, try to renew the token before reconnecting
-                            if config.get('use_auth_token'):
+                            if config.get("use_auth_token"):
                                 # Get device's public key for username
                                 device_public_key_hex = None
-                                if self.meshcore and hasattr(self.meshcore, 'self_info'):
+                                if self.meshcore and hasattr(self.meshcore, "self_info"):
                                     try:
                                         self_info = self.meshcore.self_info
                                         if isinstance(self_info, dict):
-                                            device_public_key_hex = self_info.get('public_key', '')
-                                        elif hasattr(self_info, 'public_key'):
+                                            device_public_key_hex = self_info.get("public_key", "")
+                                        elif hasattr(self_info, "public_key"):
                                             device_public_key_hex = self_info.public_key
 
                                         # Convert to hex string if bytes
@@ -1974,35 +2037,44 @@ class PacketCaptureService(BaseServicePlugin):
 
                                 if device_public_key_hex:
                                     # Create new auth token
-                                    token_audience = config.get('token_audience') or broker_host
+                                    token_audience = config.get("token_audience") or broker_host
                                     username = f"v1_{device_public_key_hex.upper()}"
 
-                                    use_device = (self.auth_token_method == 'device' and
-                                                 self.meshcore and
-                                                 self.meshcore.is_connected)
-                                    meshcore_for_key_fetch = self.meshcore if self.meshcore and self.meshcore.is_connected else None
+                                    use_device = (
+                                        self.auth_token_method == "device"
+                                        and self.meshcore
+                                        and self.meshcore.is_connected
+                                    )
+                                    meshcore_for_key_fetch = (
+                                        self.meshcore if self.meshcore and self.meshcore.is_connected else None
+                                    )
 
                                     try:
+                                        iat, exp = self._auth_token_iat_exp(config)
                                         token = await create_auth_token_async(
                                             meshcore_instance=meshcore_for_key_fetch,
                                             public_key_hex=device_public_key_hex,
                                             private_key_hex=self.private_key_hex,
                                             iata=self.global_iata,
+                                            timestamp=iat,
                                             audience=token_audience,
+                                            exp=exp,
                                             owner_public_key=self.owner_public_key,
                                             owner_email=self.owner_email,
-                                            use_device=use_device
+                                            use_device=use_device,
                                         )
                                         if token:
                                             # Update credentials
                                             client.username_pw_set(username, token)
-                                            self.logger.debug(f"Renewed auth token for {broker_host} before reconnection")
+                                            self.logger.debug(
+                                                f"Renewed auth token for {broker_host} before reconnection"
+                                            )
                                     except Exception as e:
                                         self.logger.debug(f"Error renewing auth token for {broker_host}: {e}")
 
                             # Attempt reconnection (non-blocking to avoid blocking event loop)
-                            config['host']
-                            config['port']
+                            config["host"]
+                            config["port"]
                             loop = asyncio.get_event_loop()
                             try:
                                 await loop.run_in_executor(None, client.reconnect)
@@ -2016,12 +2088,14 @@ class PacketCaptureService(BaseServicePlugin):
                             # Check if reconnection succeeded
                             if client.is_connected():
                                 self.logger.info(f"✓ Successfully reconnected to MQTT broker {broker_host}")
-                                mqtt_client_info['connected'] = True
+                                mqtt_client_info["connected"] = True
                                 # Update global flag
-                                self.mqtt_connected = any(m.get('connected', False) for m in self.mqtt_clients)
+                                self.mqtt_connected = any(m.get("connected", False) for m in self.mqtt_clients)
                             else:
                                 if self.debug:
-                                    self.logger.debug(f"Reconnection attempt to {broker_host} still in progress or failed")
+                                    self.logger.debug(
+                                        f"Reconnection attempt to {broker_host} still in progress or failed"
+                                    )
 
                         except Exception as e:
                             self.logger.debug(f"Error attempting MQTT reconnection to {broker_host}: {e}")
@@ -2031,4 +2105,3 @@ class PacketCaptureService(BaseServicePlugin):
             except Exception as e:
                 self.logger.error(f"Error in MQTT reconnection monitor: {e}")
                 await asyncio.sleep(60)
-

--- a/modules/service_plugins/repeater_prefix_collision_service.py
+++ b/modules/service_plugins/repeater_prefix_collision_service.py
@@ -439,7 +439,7 @@ class RepeaterPrefixCollisionService(BaseServicePlugin):
     async def _send_to_channels(self, text: str) -> None:
         for ch in self.channels:
             await self.bot.command_manager.send_channel_message(
-                ch, text, skip_user_rate_limit=True
+                ch, text, skip_user_rate_limit=True, scope=self.get_mesh_flood_scope()
             )
 
     def _format_location(self, row: dict[str, Any]) -> str:

--- a/modules/service_plugins/weather_service.py
+++ b/modules/service_plugins/weather_service.py
@@ -408,7 +408,8 @@ class WeatherService(BaseServicePlugin):
                 # Send to configured channel
                 await self.bot.command_manager.send_channel_message(
                     self.weather_channel,
-                    f"🌤️ Daily Weather: {forecast_text}"
+                    f"🌤️ Daily Weather: {forecast_text}",
+                    scope=self.get_mesh_flood_scope(),
                 )
                 self.logger.info(f"Daily weather forecast sent to {self.weather_channel}")
             else:
@@ -744,7 +745,8 @@ class WeatherService(BaseServicePlugin):
 
                     await self.bot.command_manager.send_channel_message(
                         self.alerts_channel,
-                        alert_text
+                        alert_text,
+                        scope=self.get_mesh_flood_scope(),
                     )
                     self.logger.info(f"Weather alert sent: {alert.get('title', 'Unknown')}")
 
@@ -973,7 +975,8 @@ class WeatherService(BaseServicePlugin):
 
                 await self.bot.command_manager.send_channel_message(
                     self.alerts_channel,
-                    message
+                    message,
+                    scope=self.get_mesh_flood_scope(),
                 )
                 self.logger.info(f"Lightning alert sent: {message}")
 

--- a/modules/service_plugins/webhook_service.py
+++ b/modules/service_plugins/webhook_service.py
@@ -24,6 +24,10 @@ POST /webhook
 
         {"channel": "general", "message": "Hello from webhook!"}
 
+    Optional regional TC_FLOOD scope (overrides [Webhook] flood_scope for this request)::
+
+        {"channel": "general", "message": "Hello", "flood_scope": "#west"}
+
     Body (DM)::
 
         {"dm_to": "SomeUser", "message": "Private message"}
@@ -230,7 +234,14 @@ class WebhookService(BaseServicePlugin):
         # --- Dispatch ---
         try:
             if channel:
-                await self._send_channel_message(channel, message_text)
+                from modules.command_manager import CommandManager
+
+                body_scope_raw = str(body.get("flood_scope") or "").strip()
+                if body_scope_raw:
+                    mesh_scope = CommandManager._normalize_scope_name(body_scope_raw)
+                else:
+                    mesh_scope = self.get_mesh_flood_scope()
+                await self._send_channel_message(channel, message_text, scope=mesh_scope)
                 self.logger.info(
                     f"Webhook: sent to #{channel} from {request.remote}: "
                     f"{message_text[:60]}{'...' if len(message_text) > 60 else ''}"
@@ -275,7 +286,9 @@ class WebhookService(BaseServicePlugin):
     # Message dispatch
     # ------------------------------------------------------------------
 
-    async def _send_channel_message(self, channel: str, message: str) -> None:
+    async def _send_channel_message(
+        self, channel: str, message: str, *, scope: str | None = None
+    ) -> None:
         """Send a message to a MeshCore channel via command_manager."""
         cm = getattr(self.bot, "command_manager", None)
         if cm is None:
@@ -285,6 +298,7 @@ class WebhookService(BaseServicePlugin):
             message,
             skip_user_rate_limit=True,
             rate_limit_key=None,
+            scope=scope,
         )
 
     async def _send_dm(self, recipient: str, message: str) -> None:

--- a/modules/service_plugins/webhook_service.py
+++ b/modules/service_plugins/webhook_service.py
@@ -237,10 +237,11 @@ class WebhookService(BaseServicePlugin):
                 from modules.command_manager import CommandManager
 
                 body_scope_raw = str(body.get("flood_scope") or "").strip()
-                if body_scope_raw:
-                    mesh_scope = CommandManager._normalize_scope_name(body_scope_raw)
-                else:
-                    mesh_scope = self.get_mesh_flood_scope()
+                mesh_scope: str | None = (
+                    CommandManager._normalize_scope_name(body_scope_raw)
+                    if body_scope_raw
+                    else self.get_mesh_flood_scope()
+                )
                 await self._send_channel_message(channel, message_text, scope=mesh_scope)
                 self.logger.info(
                     f"Webhook: sent to #{channel} from {request.remote}: "

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1818,6 +1818,55 @@ def extract_path_node_ids_from_message(message: Any) -> list[str]:
     return []
 
 
+def _normalized_message_path_string(message: Any) -> str:
+    """Strip route suffix and hop-count suffix from message.path for continuous-hex parsing."""
+    path_string = (getattr(message, 'path', None) or '').strip()
+    if not path_string or 'Direct' in path_string or '0 hops' in path_string:
+        return ''
+    if ' via ROUTE_TYPE_' in path_string:
+        path_string = path_string.split(' via ROUTE_TYPE_')[0]
+    path_string = re.sub(r'\s*\([^)]*hops?[^)]*\)', '', path_string, flags=re.IGNORECASE).strip()
+    return path_string
+
+
+def bytes_per_hop_from_routing_and_nodes(
+    routing_info: Optional[dict[str, Any]],
+    node_ids: list[str],
+) -> int:
+    """Bytes per hop from packet routing metadata, else inferred from hex node width.
+
+    When ``routing_info`` includes ``bytes_per_hop`` in 1..3, that value wins.
+    Otherwise uses minimum half-byte width among ``node_ids`` (comma or path_nodes).
+    Returns ``1`` when no nodes (direct / unknown).
+    """
+    if routing_info:
+        bph = routing_info.get('bytes_per_hop')
+        if isinstance(bph, int) and 1 <= bph <= 3:
+            return bph
+    if node_ids:
+        return min(len(n) // 2 for n in node_ids)
+    return 1
+
+
+def message_path_bytes_per_hop(message: Any, *, prefix_hex_chars: int = 2) -> int:
+    """Best-effort bytes per hop for the message path (RF metadata or inferred from path text).
+
+    Uses ``routing_info.bytes_per_hop`` when present (1..3). Otherwise prefers
+    :func:`extract_path_node_ids_from_message`, then comma/continuous hex via
+    :func:`node_ids_from_path_string` using ``prefix_hex_chars`` for legacy paths.
+
+    Returns ``1`` when no usable path (direct / unparseable) so conservative gates
+    (e.g. ``pathbytes_min:2``) do not treat unknown as multibyte.
+    """
+    routing_info = getattr(message, 'routing_info', None)
+    node_ids = extract_path_node_ids_from_message(message)
+    if not node_ids:
+        ps = _normalized_message_path_string(message)
+        if ps:
+            node_ids = node_ids_from_path_string(ps, prefix_hex_chars)
+    return bytes_per_hop_from_routing_and_nodes(routing_info, node_ids)
+
+
 def node_ids_from_path_string(path_str: str, prefix_hex_chars: int = 2) -> list[str]:
     """Parse path display string into node IDs: multi-byte comma tokens, else fixed-width scan.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meshcore-bot"
-version = "0.9.0"
+version = "0.9.1"
 description = "MeshCore Bot with commands for mesh testing, utilities, and service integration."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -15,7 +15,7 @@ VERSION="${1:-}"
 if [[ -z "${VERSION}" ]]; then
     VERSION="$(python3 -c "import tomllib; d=tomllib.load(open('${PROJECT_ROOT}/pyproject.toml','rb')); print(d['project']['version'])" 2>/dev/null || \
                python3 -c "import tomli; d=tomli.load(open('${PROJECT_ROOT}/pyproject.toml','rb')); print(d['project']['version'])" 2>/dev/null || \
-               grep -Po '(?<=^version = ")([^"]+)' "${PROJECT_ROOT}/pyproject.toml" || echo "0.9.0")"
+               grep -Po '(?<=^version = ")([^"]+)' "${PROJECT_ROOT}/pyproject.toml" || echo "0.9.1")"
 fi
 
 # Validate VERSION: must be semver-like (digits and dots only) to prevent

--- a/scripts/reload_config.sh
+++ b/scripts/reload_config.sh
@@ -23,14 +23,19 @@ CONFIG="${1:-config.ini}"
 # --- read port and token from config.ini unless overridden by env -----
 _read_config_value() {
     local key="$1" default="$2"
+    local value=""
     if [ -f "$CONFIG" ]; then
-        grep -A20 '^\[Admin\]' "$CONFIG" \
+        value="$(grep -A20 '^\[Admin\]' "$CONFIG" \
             | grep -m1 "^${key}[[:space:]]*=" \
             | sed 's/^[^=]*=[[:space:]]*//' \
             | tr -d '[:space:]' \
-            || true
+            || true)"
     fi
-    # fall through to default if nothing printed
+    if [ -n "$value" ]; then
+        printf '%s\n' "$value"
+    else
+        printf '%s\n' "$default"
+    fi
 }
 
 ADMIN_PORT="${ADMIN_PORT:-$(_read_config_value port 5001)}"

--- a/tests/integration/test_flood_scope_reply.py
+++ b/tests/integration/test_flood_scope_reply.py
@@ -289,6 +289,53 @@ async def test_send_response_passes_none_scope_when_unset():
     assert kwargs.get("scope") is None
 
 
+@pytest.mark.asyncio
+async def test_send_response_forwards_command_id_to_channel_send():
+    """Optional command_id is passed to send_channel_message for repeat tracking."""
+    bot = MagicMock()
+    bot.logger = Mock()
+    bot.config = make_config()
+    bot.connected = True
+    bot.meshcore = MagicMock()
+
+    cm = object.__new__(CommandManager)
+    cm.bot = bot
+    cm.logger = bot.logger
+    cm.send_channel_message = AsyncMock(return_value=True)
+    cm.get_rate_limit_key = Mock(return_value="rk")
+
+    msg = MeshMessage(content="hello", channel="general", is_dm=False, sender_id="Alice")
+    await cm.send_response(msg, "reply text", command_id="keyword_foo_1")
+
+    cm.send_channel_message.assert_awaited_once()
+    args, kwargs = cm.send_channel_message.call_args
+    assert args[2] == "keyword_foo_1"
+    assert kwargs.get("scope") is None
+
+
+@pytest.mark.asyncio
+async def test_send_response_forwards_command_id_to_dm():
+    """Optional command_id is passed to send_dm for repeat tracking."""
+    bot = MagicMock()
+    bot.logger = Mock()
+    bot.config = make_config()
+    bot.connected = True
+    bot.meshcore = MagicMock()
+
+    cm = object.__new__(CommandManager)
+    cm.bot = bot
+    cm.logger = bot.logger
+    cm.send_dm = AsyncMock(return_value=True)
+    cm.get_rate_limit_key = Mock(return_value="rk")
+
+    msg = MeshMessage(content="hello", channel=None, is_dm=True, sender_id="Bob")
+    await cm.send_response(msg, "reply text", command_id="keyword_bar_2")
+
+    cm.send_dm.assert_awaited_once()
+    args, kwargs = cm.send_dm.call_args
+    assert args[2] == "keyword_bar_2"
+
+
 # ── scope normalization in send_channel_message ───────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/integration/test_flood_scope_reply.py
+++ b/tests/integration/test_flood_scope_reply.py
@@ -139,6 +139,25 @@ class TestFloodScopeKeysLoading:
         result = cm._load_flood_scope_keys()
         assert result == {}
 
+    def test_flood_scopes_in_bot_section_fallback(self):
+        config = configparser.ConfigParser()
+        config.add_section("Bot")
+        config.set("Bot", "bot_name", "TestBot")
+        config.set("Bot", "flood_scopes", "w-wa, *")
+        config.add_section("Channels")
+        config.set("Channels", "monitor_channels", "general")
+        bot = MagicMock()
+        bot.logger = Mock()
+        bot.config = config
+        cm = object.__new__(CommandManager)
+        cm.bot = bot
+        cm.logger = Mock()
+        cm.flood_scope_allow_global = False
+        result = cm._load_flood_scope_keys()
+        assert "#w-wa" in result
+        assert cm.flood_scope_allow_global is True
+        cm.logger.warning.assert_called_once()
+
     def test_star_excluded_from_scope_keys(self):
         bot = MagicMock()
         bot.logger = Mock()
@@ -371,3 +390,131 @@ async def test_send_channel_message_normalizes_bare_scope():
     calls = set_flood_scope.await_args_list
     scope_set = [c.args[0] for c in calls if c.args]
     assert "#west" in scope_set
+
+
+# ── Production #snoco scoped ping regression (2026-05-16) ─────────────────────
+
+# Captured from live TC_FLOOD channel ping on #bot: tc_code1=30332, GRP_TXT type 5.
+SNOCO_SCOPED_PING_PAYLOAD = bytes.fromhex(
+    "ca06625f8e52006332d36687f6499583e61e32753b17ade613e3a648adf8cbf7c1b03b"
+)
+SNOCO_SCOPED_PING_TC_CODE1 = 30332
+
+
+class TestSnocoScopedPingRegression:
+    """Regression for scoped ping → reply_scope #snoco → outbound send scope."""
+
+    def _load_user_style_scope_keys(self) -> dict[str, bytes]:
+        bot = MagicMock()
+        bot.logger = Mock()
+        bot.config = make_config(flood_scopes="*,wa,w-wa,sea,snoco,pnw,west")
+        cm = object.__new__(CommandManager)
+        cm.bot = bot
+        cm.logger = Mock()
+        cm.flood_scope_allow_global = False
+        return cm._load_flood_scope_keys()
+
+    def _production_rf_cache(self) -> dict:
+        return {
+            "route_type_int": 0,
+            "transport_code1": SNOCO_SCOPED_PING_TC_CODE1,
+            "payload_type_int": PAYLOAD_TYPE,
+            "scope_payload_hex": SNOCO_SCOPED_PING_PAYLOAD.hex(),
+            "raw_hex": (
+                "30dd147c76000040ca06625f8e52006332d36687f6499583e61e32753b17ade613e3a648adf8cbf7c1b03b"
+            ),
+        }
+
+    def _production_packet_info(self) -> dict:
+        return {
+            "route_type": 0,
+            "transport_codes": {"code1": SNOCO_SCOPED_PING_TC_CODE1, "code2": 0},
+            "payload_type": PAYLOAD_TYPE,
+            "payload_hex": SNOCO_SCOPED_PING_PAYLOAD.hex(),
+        }
+
+    def test_production_hmac_matches_snoco_not_w_wa(self):
+        scope_keys = self._load_user_style_scope_keys()
+        assert "#snoco" in scope_keys
+        assert MessageHandler._match_scope(
+            SNOCO_SCOPED_PING_TC_CODE1,
+            PAYLOAD_TYPE,
+            SNOCO_SCOPED_PING_PAYLOAD,
+            scope_keys,
+        ) == "#snoco"
+        assert MessageHandler._match_scope(
+            SNOCO_SCOPED_PING_TC_CODE1,
+            PAYLOAD_TYPE,
+            SNOCO_SCOPED_PING_PAYLOAD,
+            {"#w-wa": scope_keys["#w-wa"]},
+        ) is None
+
+    def test_rf_cache_resolves_reply_scope_snoco(self):
+        mh = object.__new__(MessageHandler)
+        mh.logger = Mock()
+        scope_keys = self._load_user_style_scope_keys()
+        reply_scope = mh._resolve_reply_scope_from_rf_data(
+            self._production_rf_cache(),
+            self._production_packet_info(),
+            scope_keys,
+        )
+        assert reply_scope == "#snoco"
+
+    def test_stale_flood_cache_plus_decode_still_resolves_snoco(self):
+        """Correlated RF row said FLOOD but decode says TC_FLOOD (pre-fix failure mode)."""
+        mh = object.__new__(MessageHandler)
+        mh.logger = Mock()
+        scope_keys = self._load_user_style_scope_keys()
+        stale_cache = {
+            "route_type_int": 1,
+            "transport_code1": None,
+            "payload_type_int": PAYLOAD_TYPE,
+            "scope_payload_hex": "",
+        }
+        assert (
+            mh._resolve_reply_scope_from_rf_data(
+                stale_cache,
+                self._production_packet_info(),
+                scope_keys,
+            )
+            == "#snoco"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ping_reply_send_response_forwards_snoco_scope(self):
+        """MeshMessage built after scope match must pass scope=#snoco to send_channel_message."""
+        mh = object.__new__(MessageHandler)
+        mh.logger = Mock()
+        scope_keys = self._load_user_style_scope_keys()
+        reply_scope = mh._resolve_reply_scope_from_rf_data(
+            self._production_rf_cache(),
+            self._production_packet_info(),
+            scope_keys,
+        )
+        assert reply_scope == "#snoco"
+
+        bot = MagicMock()
+        bot.logger = Mock()
+        bot.config = make_config(flood_scopes="*,wa,w-wa,sea,snoco,pnw,west")
+        bot.connected = True
+        bot.meshcore = MagicMock()
+
+        cm = object.__new__(CommandManager)
+        cm.bot = bot
+        cm.logger = bot.logger
+        cm.flood_scope_keys = scope_keys
+        cm.flood_scope_allow_global = True
+        cm.send_channel_message = AsyncMock(return_value=True)
+
+        msg = MeshMessage(
+            content="Ping",
+            channel="#bot",
+            is_dm=False,
+            sender_id="HOWL",
+            reply_scope=reply_scope,
+        )
+        await cm.send_response(msg, "Pong!")
+
+        cm.send_channel_message.assert_awaited_once()
+        _, kwargs = cm.send_channel_message.call_args
+        assert kwargs.get("scope") == "#snoco"

--- a/tests/test_announcements_command.py
+++ b/tests/test_announcements_command.py
@@ -336,6 +336,23 @@ class TestExecute:
         assert result is True
         bot.command_manager.send_channel_message.assert_called_once()
 
+    def test_announcement_passes_reply_scope_to_channel_send(self):
+        from unittest.mock import AsyncMock
+        bot = _make_bot(acl_keys=[VALID_PUBKEY], triggers={"welcome": "Hello!"})
+        bot.command_manager.send_channel_message = AsyncMock(return_value=True)
+        cmd = AnnouncementsCommand(bot)
+        cmd.send_response = AsyncMock(return_value=True)
+        msg = mock_message(
+            content="announce welcome",
+            is_dm=True,
+            sender_pubkey=VALID_PUBKEY,
+            reply_scope="#west",
+        )
+        import asyncio
+        asyncio.run(cmd.execute(msg))
+        _, kwargs = bot.command_manager.send_channel_message.call_args
+        assert kwargs.get("scope") == "#west"
+
     def test_failed_announcement_send(self):
         from unittest.mock import AsyncMock
         bot = _make_bot(acl_keys=[VALID_PUBKEY], triggers={"welcome": "Hello!"})

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -434,6 +434,47 @@ class TestSendDMRecipientResolution:
         assert "Contact not found for DM recipient identifier" in cm_bot.logger.error.call_args.args[0]
 
     @pytest.mark.asyncio
+    async def test_send_response_dm_uses_sender_pubkey_over_name(self, cm_bot):
+        """send_response for a DM must use sender_pubkey (not sender_id/name) to avoid
+        misrouting when two nodes share a similar display name."""
+        from meshcore import EventType
+
+        cm_bot.connected = True
+        cm_bot.meshcore = Mock()
+        # Name lookup by display name would resolve the WRONG node (same name prefix)
+        cm_bot.meshcore.get_contact_by_name = Mock(return_value=None)
+        cm_bot.meshcore.contacts = {
+            "contact1": {
+                "name": "Alice",
+                "adv_name": "Alice",
+                "public_key": "aabbccddeeff001122",
+            },
+            "contact2": {
+                "name": "Alice-repeater",
+                "adv_name": "Alice-repeater",
+                "public_key": "ffeeddccbbaa998877",
+            },
+        }
+        cm_bot.meshcore.commands = Mock(spec=["send_msg"])
+        cm_bot.meshcore.commands.send_msg = AsyncMock(return_value=Mock(type=EventType.MSG_SENT, payload=None))
+        cm_bot.bot_tx_rate_limiter.wait_for_tx = AsyncMock(return_value=None)
+        manager = make_manager(cm_bot)
+
+        msg = MeshMessage(
+            content="hello",
+            sender_id="Alice",
+            sender_pubkey="aabbccddeeff001122",
+            is_dm=True,
+        )
+
+        result = await manager.send_response(msg, "Hi back")
+
+        assert result is True
+        cm_bot.meshcore.get_contact_by_name.assert_called_once_with("aabbccddeeff001122")
+        sent_contact = cm_bot.meshcore.commands.send_msg.await_args.args[0]
+        assert sent_contact["public_key"] == "aabbccddeeff001122"
+
+    @pytest.mark.asyncio
     async def test_failed_send_does_not_invoke_listeners(self, cm_bot):
         """When send_channel_message fails (e.g. channel not found), listeners are not called."""
         cm_bot.connected = True

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1213,6 +1213,32 @@ class TestParseAdvert:
         result = handler.parse_advert(payload)
         assert result["mode"] == "Type5"
 
+    def test_advert_flags_0xfd_invalid_for_python_flag_still_parses(self, handler):
+        """0xFD sets type nibble 0x0D; enum.Flag rejected this — parsing must match firmware bit tests."""
+        payload = _make_advert_payload(
+            0xFD,
+            location_lat_raw=1000000,
+            location_lon_raw=-2000000,
+            feat1=0x0001,
+            feat2=0x0002,
+            name="CorruptWire",
+        )
+        result = handler.parse_advert(payload)
+        assert result != {}
+        assert result["mode"] == "Type13"
+        assert result["lat"] == 1.0
+        assert result["lon"] == -2.0
+        assert result["feat1"] == 0x0001
+        assert result["feat2"] == 0x0002
+        assert result["name"] == "CorruptWire"
+
+    def test_advert_type_nibble_8_no_extra_flags(self, handler):
+        """Low nibble 8 sets bit 0x08 alone — must not raise."""
+        payload = _make_advert_payload(0x08)
+        result = handler.parse_advert(payload)
+        assert result["mode"] == "Type8"
+        assert "lat" not in result
+
     def test_companion_with_name(self, handler):
         # ADV_NAME_MASK=0x80 | ADV_TYPE_CHAT=0x01
         payload = _make_advert_payload(0x81, name="TestNode")

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1849,8 +1849,8 @@ class TestProcessMessageDmKeywordRouting:
     """Regression tests for DM keyword reply routing."""
 
     @pytest.mark.asyncio
-    async def test_keyword_reply_uses_prefix_sender_id_for_dm_send(self, handler):
-        """DM keyword flow should route reply using prefix sender identity."""
+    async def test_keyword_reply_uses_pubkey_for_dm_send(self, handler):
+        """DM keyword flow should route reply via send_response using pubkey identity."""
         handler.should_process_message = Mock(return_value=True)
         handler.bot.command_manager.check_keywords = Mock(return_value=[("test", "ack")])
         handler.bot.command_manager.match_randomline = Mock(return_value=None)

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1952,7 +1952,11 @@ def new_contact_env(mock_logger):
     bot.message_handler = handler
 
     rm = Mock()
-    rm.track_contact_advertisement = AsyncMock()
+    from modules.repeater_manager import TrackAdvertResult
+
+    rm.track_contact_advertisement = AsyncMock(
+        return_value=TrackAdvertResult(ok=True, duplicate_packet=False)
+    )
     rm.check_and_auto_purge = AsyncMock()
     rm.get_contact_list_status = AsyncMock(
         return_value={
@@ -2007,3 +2011,34 @@ class TestHandleNewContactAutoManage:
         await handler.handle_new_contact(ev, None)
         rm.add_companion_from_contact_data.assert_awaited_once()
         mesh.commands.add_contact.assert_not_called()
+
+    async def test_bot_mode_skips_add_when_duplicate_packet_hash(self, new_contact_env):
+        from modules.repeater_manager import TrackAdvertResult
+
+        bot, handler, rm, mesh = new_contact_env
+        bot.config.set("Bot", "auto_manage_contacts", "bot")
+        rm.track_contact_advertisement = AsyncMock(
+            return_value=TrackAdvertResult(ok=True, duplicate_packet=True)
+        )
+        ev = _NewContactEvent(_companion_contact_payload())
+        await handler.handle_new_contact(ev, None)
+        rm.track_contact_advertisement.assert_awaited_once()
+        rm.add_companion_from_contact_data.assert_not_called()
+        rm.get_contact_list_status.assert_not_awaited()
+
+    async def test_bot_mode_two_events_first_unique_then_duplicate_adds_once(self, new_contact_env):
+        from modules.repeater_manager import TrackAdvertResult
+
+        bot, handler, rm, mesh = new_contact_env
+        bot.config.set("Bot", "auto_manage_contacts", "bot")
+        rm.track_contact_advertisement = AsyncMock(
+            side_effect=[
+                TrackAdvertResult(ok=True, duplicate_packet=False),
+                TrackAdvertResult(ok=True, duplicate_packet=True),
+            ]
+        )
+        ev = _NewContactEvent(_companion_contact_payload())
+        await handler.handle_new_contact(ev, None)
+        await handler.handle_new_contact(ev, None)
+        assert rm.track_contact_advertisement.await_count == 2
+        rm.add_companion_from_contact_data.assert_awaited_once()

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1856,7 +1856,7 @@ class TestProcessMessageDmKeywordRouting:
         handler.bot.command_manager.match_randomline = Mock(return_value=None)
         handler.bot.command_manager.execute_commands = AsyncMock()
         handler.bot.command_manager.get_rate_limit_key = Mock(return_value="ab12deadbeef")
-        handler.bot.command_manager.send_dm = AsyncMock(return_value=True)
+        handler.bot.command_manager.send_response = AsyncMock(return_value=True)
         handler.bot.command_manager.commands = {}
 
         message = MeshMessage(
@@ -1868,12 +1868,40 @@ class TestProcessMessageDmKeywordRouting:
 
         await handler.process_message(message)
 
-        handler.bot.command_manager.send_dm.assert_awaited_once()
-        args, kwargs = handler.bot.command_manager.send_dm.await_args
-        assert args[0] == "ab12"
-        assert args[1] == "ack"
-        assert args[2].startswith("keyword_test_ab12_")
-        assert kwargs["rate_limit_key"] == "ab12deadbeef"
+        handler.bot.command_manager.send_response.assert_awaited_once()
+        call = handler.bot.command_manager.send_response.await_args
+        assert call.args[0] is message
+        assert call.args[1] == "ack"
+        assert call.kwargs["command_id"].startswith("keyword_test_ab12_")
+
+
+class TestProcessMessageChannelKeywordFloodScope:
+    """Keyword channel replies must use send_response so flood scope is applied (#178)."""
+
+    @pytest.mark.asyncio
+    async def test_keyword_channel_reply_passes_message_with_reply_scope(self, handler, bot):
+        handler.should_process_message = Mock(return_value=True)
+        bot.command_manager.check_keywords = Mock(return_value=[("wx", "sunny")])
+        bot.command_manager.match_randomline = Mock(return_value=None)
+        bot.command_manager.execute_commands = AsyncMock()
+        bot.command_manager.send_response = AsyncMock(return_value=True)
+        bot.command_manager.commands = {}
+
+        message = MeshMessage(
+            content="wx",
+            channel="#bot",
+            is_dm=False,
+            sender_id="alice",
+            reply_scope="#pl-mz",
+        )
+
+        await handler.process_message(message)
+
+        bot.command_manager.send_response.assert_awaited_once()
+        call = bot.command_manager.send_response.await_args
+        assert call.args[0].reply_scope == "#pl-mz"
+        assert call.args[1] == "sunny"
+        assert call.kwargs["command_id"].startswith("keyword_wx_alice_")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_message_handler_contact_path.py
+++ b/tests/test_message_handler_contact_path.py
@@ -6,7 +6,7 @@ import pytest
 from meshcore import EventType
 
 from modules.message_handler import MessageHandler
-from modules.repeater_manager import RepeaterManager
+from modules.repeater_manager import RepeaterManager, TrackAdvertResult
 
 
 def _make_config_get():
@@ -57,7 +57,9 @@ def companion_new_contact_setup():
     rm.bot = bot
     rm.logger = bot.logger
     rm._is_repeater_device = MagicMock(return_value=False)
-    rm.track_contact_advertisement = AsyncMock()
+    rm.track_contact_advertisement = AsyncMock(
+        return_value=TrackAdvertResult(ok=True, duplicate_packet=False)
+    )
     rm.check_and_auto_purge = AsyncMock()
     rm.get_contact_list_status = AsyncMock(
         return_value={"is_near_limit": False, "usage_percentage": 0.0}

--- a/tests/test_repeater_manager.py
+++ b/tests/test_repeater_manager.py
@@ -734,17 +734,23 @@ class TestTrackContactAdvertisement:
         return data
 
     async def test_missing_public_key_returns_false(self, rm):
-        """Advertisement without public_key should return False immediately."""
+        """Advertisement without public_key should return ok=False immediately."""
+        from modules.repeater_manager import TrackAdvertResult
+
         result = await rm.track_contact_advertisement({"name": "Nameless"})
-        assert result is False
+        assert result == TrackAdvertResult(ok=False, duplicate_packet=False)
         rm.logger.warning.assert_called()
 
     async def test_empty_public_key_returns_false(self, rm):
+        from modules.repeater_manager import TrackAdvertResult
+
         result = await rm.track_contact_advertisement({"public_key": "", "name": "X"})
-        assert result is False
+        assert result == TrackAdvertResult(ok=False, duplicate_packet=False)
 
     async def test_new_contact_inserted_returns_true(self, rm):
-        """New contact (not in DB) is inserted and True is returned."""
+        """New contact (not in DB) is inserted and ok=True, duplicate_packet=False."""
+        from modules.repeater_manager import TrackAdvertResult
+
         advert = self._make_advert()
 
         rm.bot.meshcore = Mock()
@@ -752,7 +758,7 @@ class TestTrackContactAdvertisement:
 
         result = await rm.track_contact_advertisement(advert)
 
-        assert result is True
+        assert result == TrackAdvertResult(ok=True, duplicate_packet=False)
         # Verify the contact was actually inserted into the DB
         rows = rm.db_manager.execute_query(
             'SELECT * FROM complete_contact_tracking WHERE public_key = ?',
@@ -771,9 +777,11 @@ class TestTrackContactAdvertisement:
         await rm.track_contact_advertisement(advert)
 
         # Call again — should update existing entry, incrementing advert_count
+        from modules.repeater_manager import TrackAdvertResult
+
         result = await rm.track_contact_advertisement(advert)
 
-        assert result is True
+        assert result == TrackAdvertResult(ok=True, duplicate_packet=False)
         rows = rm.db_manager.execute_query(
             'SELECT advert_count FROM complete_contact_tracking WHERE public_key = ?',
             ('aabb1122',)
@@ -781,14 +789,17 @@ class TestTrackContactAdvertisement:
         assert rows[0]['advert_count'] == 2
 
     async def test_duplicate_packet_hash_skips_and_returns_true(self, rm):
-        """When packet_hash is already in unique_advert_packets, return True without re-inserting."""
+        """When packet_hash is already in unique_advert_packets, duplicate_packet=True without re-inserting."""
+        from modules.repeater_manager import TrackAdvertResult
+
         advert = self._make_advert()
         packet_hash = "deadbeef12345678"
         rm.bot.meshcore = Mock()
         rm.bot.meshcore.contacts = {}
 
         # First call inserts the contact and records the packet hash
-        await rm.track_contact_advertisement(advert, packet_hash=packet_hash)
+        first = await rm.track_contact_advertisement(advert, packet_hash=packet_hash)
+        assert first == TrackAdvertResult(ok=True, duplicate_packet=False)
         rows_before = rm.db_manager.execute_query(
             'SELECT advert_count FROM complete_contact_tracking WHERE public_key = ?',
             ('aabb1122',)
@@ -797,7 +808,7 @@ class TestTrackContactAdvertisement:
         # Second call with same packet_hash should skip the update
         result = await rm.track_contact_advertisement(advert, packet_hash=packet_hash)
 
-        assert result is True
+        assert result == TrackAdvertResult(ok=True, duplicate_packet=True)
         rows_after = rm.db_manager.execute_query(
             'SELECT advert_count FROM complete_contact_tracking WHERE public_key = ?',
             ('aabb1122',)
@@ -813,9 +824,11 @@ class TestTrackContactAdvertisement:
         rm.bot.meshcore = Mock()
         rm.bot.meshcore.contacts = {}
 
+        from modules.repeater_manager import TrackAdvertResult
+
         result = await rm.track_contact_advertisement(advert, signal_info=signal_info)
 
-        assert result is True
+        assert result == TrackAdvertResult(ok=True, duplicate_packet=False)
         rows = rm.db_manager.execute_query(
             'SELECT signal_strength, snr FROM complete_contact_tracking WHERE public_key = ?',
             ('direct_hop_key',)
@@ -841,13 +854,15 @@ class TestTrackContactAdvertisement:
         assert rows[0]['snr'] is None
 
     async def test_db_exception_returns_false(self, rm):
-        """An unexpected exception during DB operations should return False."""
+        """An unexpected exception during DB operations should return ok=False."""
         advert = self._make_advert()
         rm.db_manager.execute_query_on_connection = Mock(side_effect=Exception("db exploded"))
 
+        from modules.repeater_manager import TrackAdvertResult
+
         result = await rm.track_contact_advertisement(advert)
 
-        assert result is False
+        assert result == TrackAdvertResult(ok=False, duplicate_packet=False)
         rm.logger.error.assert_called()
 
     async def test_daily_stats_updated_on_insert(self, rm):
@@ -856,9 +871,11 @@ class TestTrackContactAdvertisement:
         rm.bot.meshcore = Mock()
         rm.bot.meshcore.contacts = {}
 
+        from modules.repeater_manager import TrackAdvertResult
+
         result = await rm.track_contact_advertisement(advert)
 
-        assert result is True
+        assert result == TrackAdvertResult(ok=True, duplicate_packet=False)
         # Verify daily_stats was inserted
         from datetime import date
         rows = rm.db_manager.execute_query(

--- a/tests/test_schedule_command.py
+++ b/tests/test_schedule_command.py
@@ -87,22 +87,22 @@ class TestBuildResponseEmpty:
 class TestBuildResponseWithSchedules:
     def test_shows_scheduled_count(self, bot):
         bot.scheduler.scheduled_messages = {
-            "0900": ("general", "Good morning!", "09:00"),
-            "1800": ("general", "Good evening!", "18:00"),
+            "0900": ("general", "Good morning!", "09:00", None),
+            "1800": ("general", "Good evening!", "18:00", None),
         }
         cmd = make_cmd(bot)
         response = cmd._build_response()
         assert "Scheduled (2)" in response
 
     def test_formats_time_as_hhmm(self, bot):
-        bot.scheduler.scheduled_messages = {"0930": ("general", "Hello", "09:30")}
+        bot.scheduler.scheduled_messages = {"0930": ("general", "Hello", "09:30", None)}
         cmd = make_cmd(bot)
         response = cmd._build_response()
         assert "09:30" in response
 
     def test_shows_channel_and_message(self, bot):
         bot.scheduler.scheduled_messages = {
-            "1200": ("alerts", "Noon check-in", "12:00"),
+            "1200": ("alerts", "Noon check-in", "12:00", None),
         }
         cmd = make_cmd(bot)
         response = cmd._build_response()
@@ -111,7 +111,7 @@ class TestBuildResponseWithSchedules:
 
     def test_long_message_is_truncated(self, bot):
         long_msg = "A" * 100
-        bot.scheduler.scheduled_messages = {"0800": ("general", long_msg, "08:00")}
+        bot.scheduler.scheduled_messages = {"0800": ("general", long_msg, "08:00", None)}
         cmd = make_cmd(bot)
         response = cmd._build_response()
         # Preview should be ≤43 chars (40 + "...")
@@ -124,9 +124,9 @@ class TestBuildResponseWithSchedules:
 
     def test_entries_sorted_by_time(self, bot):
         bot.scheduler.scheduled_messages = {
-            "1800": ("general", "Evening", "18:00"),
-            "0600": ("general", "Morning", "06:00"),
-            "1200": ("general", "Noon", "12:00"),
+            "1800": ("general", "Evening", "18:00", None),
+            "0600": ("general", "Morning", "06:00", None),
+            "1200": ("general", "Noon", "12:00", None),
         }
         cmd = make_cmd(bot)
         response = cmd._build_response()
@@ -136,16 +136,26 @@ class TestBuildResponseWithSchedules:
 
     def test_shows_cron_schedule_string(self, bot):
         bot.scheduler.scheduled_messages = {
-            "0 9 * * *": ("general", "Cron hello", "0 9 * * *"),
+            "0 9 * * *": ("general", "Cron hello", "0 9 * * *", None),
         }
         cmd = make_cmd(bot)
         response = cmd._build_response()
         assert "0 9 * * *" in response
         assert "Cron hello" in response
 
+    def test_shows_flood_scope_when_set(self, bot):
+        bot.scheduler.scheduled_messages = {
+            "0 18 * * *": ("Public", "Hello mesh", "0 18 * * *", "#sea"),
+        }
+        cmd = make_cmd(bot)
+        response = cmd._build_response()
+        assert "(#sea)" in response
+        assert "#Public" in response
+        assert "Hello mesh" in response
+
     def test_shows_at_preset_label(self, bot):
         bot.scheduler.scheduled_messages = {
-            "@hourly": ("general", "tick", "@hourly"),
+            "@hourly": ("general", "tick", "@hourly", None),
         }
         cmd = make_cmd(bot)
         response = cmd._build_response()

--- a/tests/test_schedule_command.py
+++ b/tests/test_schedule_command.py
@@ -87,21 +87,23 @@ class TestBuildResponseEmpty:
 class TestBuildResponseWithSchedules:
     def test_shows_scheduled_count(self, bot):
         bot.scheduler.scheduled_messages = {
-            "0900": ("general", "Good morning!"),
-            "1800": ("general", "Good evening!"),
+            "0900": ("general", "Good morning!", "09:00"),
+            "1800": ("general", "Good evening!", "18:00"),
         }
         cmd = make_cmd(bot)
         response = cmd._build_response()
         assert "Scheduled (2)" in response
 
     def test_formats_time_as_hhmm(self, bot):
-        bot.scheduler.scheduled_messages = {"0930": ("general", "Hello")}
+        bot.scheduler.scheduled_messages = {"0930": ("general", "Hello", "09:30")}
         cmd = make_cmd(bot)
         response = cmd._build_response()
         assert "09:30" in response
 
     def test_shows_channel_and_message(self, bot):
-        bot.scheduler.scheduled_messages = {"1200": ("alerts", "Noon check-in")}
+        bot.scheduler.scheduled_messages = {
+            "1200": ("alerts", "Noon check-in", "12:00"),
+        }
         cmd = make_cmd(bot)
         response = cmd._build_response()
         assert "#alerts" in response
@@ -109,7 +111,7 @@ class TestBuildResponseWithSchedules:
 
     def test_long_message_is_truncated(self, bot):
         long_msg = "A" * 100
-        bot.scheduler.scheduled_messages = {"0800": ("general", long_msg)}
+        bot.scheduler.scheduled_messages = {"0800": ("general", long_msg, "08:00")}
         cmd = make_cmd(bot)
         response = cmd._build_response()
         # Preview should be ≤43 chars (40 + "...")
@@ -122,15 +124,33 @@ class TestBuildResponseWithSchedules:
 
     def test_entries_sorted_by_time(self, bot):
         bot.scheduler.scheduled_messages = {
-            "1800": ("general", "Evening"),
-            "0600": ("general", "Morning"),
-            "1200": ("general", "Noon"),
+            "1800": ("general", "Evening", "18:00"),
+            "0600": ("general", "Morning", "06:00"),
+            "1200": ("general", "Noon", "12:00"),
         }
         cmd = make_cmd(bot)
         response = cmd._build_response()
         lines = [l for l in response.splitlines() if ":" in l and "#" in l]
         times = [l.strip().split(" ")[0] for l in lines]
         assert times == sorted(times)
+
+    def test_shows_cron_schedule_string(self, bot):
+        bot.scheduler.scheduled_messages = {
+            "0 9 * * *": ("general", "Cron hello", "0 9 * * *"),
+        }
+        cmd = make_cmd(bot)
+        response = cmd._build_response()
+        assert "0 9 * * *" in response
+        assert "Cron hello" in response
+
+    def test_shows_at_preset_label(self, bot):
+        bot.scheduler.scheduled_messages = {
+            "@hourly": ("general", "tick", "@hourly"),
+        }
+        cmd = make_cmd(bot)
+        response = cmd._build_response()
+        assert "@hourly" in response
+        assert "tick" in response
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduled_message_cron.py
+++ b/tests/test_scheduled_message_cron.py
@@ -1,0 +1,48 @@
+"""Tests for scheduled_message_cron value parsing."""
+
+import pytest
+
+from modules.scheduled_message_cron import parse_scheduled_message_value
+
+
+class TestParseScheduledMessageValue:
+    def test_legacy_channel_body(self):
+        ch, msg, scope = parse_scheduled_message_value("Public:Hello!")
+        assert ch == "Public"
+        assert msg == "Hello!"
+        assert scope is None
+
+    def test_scoped_channel_scope_body(self):
+        ch, msg, scope = parse_scheduled_message_value("Public:#sea:Hello!")
+        assert ch == "Public"
+        assert scope == "#sea"
+        assert msg == "Hello!"
+
+    def test_scoped_body_may_contain_colons(self):
+        ch, msg, scope = parse_scheduled_message_value("Public:#sea:Hello: with colons")
+        assert ch == "Public"
+        assert scope == "#sea"
+        assert msg == "Hello: with colons"
+
+    def test_three_parts_middle_not_hash_is_legacy(self):
+        ch, msg, scope = parse_scheduled_message_value("Public:Hello: world")
+        assert ch == "Public"
+        assert msg == "Hello: world"
+        assert scope is None
+
+    def test_strips_whitespace(self):
+        ch, msg, scope = parse_scheduled_message_value("  gen : #w : hi  ")
+        assert ch == "gen"
+        assert scope == "#w"
+        assert msg == "hi"
+
+    def test_no_colon_raises(self):
+        with pytest.raises(ValueError):
+            parse_scheduled_message_value("nocolon")
+
+    def test_only_channel_hash_scope_two_segments_legacy(self):
+        """Two segments after split(':',2) — middle does not get # form; legacy parse."""
+        ch, msg, scope = parse_scheduled_message_value("Public:#sea")
+        assert ch == "Public"
+        assert msg == "#sea"
+        assert scope is None

--- a/tests/test_scheduler_logic.py
+++ b/tests/test_scheduler_logic.py
@@ -2,11 +2,14 @@
 
 import datetime
 import time
+from zoneinfo import ZoneInfo
+
 from configparser import ConfigParser
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from modules.scheduled_message_cron import parse_schedule_key
 from modules.scheduler import MessageScheduler
 
 
@@ -18,6 +21,36 @@ def scheduler(mock_logger):
     bot.config = ConfigParser()
     bot.config.add_section("Bot")
     return MessageScheduler(bot)
+
+
+class TestParseScheduleKey:
+    """Tests for scheduled message cron / preset / legacy parsing."""
+
+    def test_five_field_cron(self):
+        tz = ZoneInfo("UTC")
+        r = parse_schedule_key("30 14 * * *", tz)
+        assert r.trigger is not None
+        assert r.display_label == "30 14 * * *"
+        assert r.is_deprecated_hhmm is False
+
+    def test_at_daily_preset(self):
+        tz = ZoneInfo("UTC")
+        r = parse_schedule_key("@daily", tz)
+        assert r.trigger is not None
+        assert r.display_label == "@daily"
+        assert r.is_deprecated_hhmm is False
+
+    def test_legacy_hhmm(self):
+        tz = ZoneInfo("UTC")
+        r = parse_schedule_key("0900", tz)
+        assert r.trigger is not None
+        assert r.display_label == "09:00"
+        assert r.is_deprecated_hhmm is True
+
+    def test_invalid_expression(self):
+        tz = ZoneInfo("UTC")
+        r = parse_schedule_key("not-a-valid-cron", tz)
+        assert r.trigger is None
 
 
 class TestIsValidTimeFormat:
@@ -106,10 +139,61 @@ class TestSetupScheduledMessages:
         scheduler.bot.config.set("Scheduled_Messages", "0900", "general: Good morning!")
         self._setup_and_call(scheduler)
         assert "0900" in scheduler.scheduled_messages
-        channel, message = scheduler.scheduled_messages["0900"]
+        channel, message, label = scheduler.scheduled_messages["0900"]
         assert channel == "general"
         assert "Good morning!" in message
+        assert label == "09:00"
         assert len(scheduler._apscheduler.get_jobs()) == 1
+        self._teardown(scheduler)
+
+    def test_deprecated_hhmm_logs_migration_warning(self, scheduler):
+        scheduler.bot.config.add_section("Scheduled_Messages")
+        scheduler.bot.config.set("Scheduled_Messages", "0900", "general: Hi")
+        self._setup_and_call(scheduler)
+        warns = [str(c) for c in scheduler.bot.logger.warning.call_args_list]
+        assert any("deprecated" in w.lower() for w in warns)
+        assert any("HHMM" in w for w in warns)
+        self._teardown(scheduler)
+
+    def test_five_field_cron_registered(self, scheduler):
+        scheduler.bot.config.add_section("Scheduled_Messages")
+        scheduler.bot.config.set(
+            "Scheduled_Messages", "0 9 * * *", "general: Morning cron"
+        )
+        self._setup_and_call(scheduler)
+        assert "0 9 * * *" in scheduler.scheduled_messages
+        ch, msg, label = scheduler.scheduled_messages["0 9 * * *"]
+        assert ch == "general"
+        assert "Morning cron" in msg
+        assert label == "0 9 * * *"
+        assert len(scheduler._apscheduler.get_jobs()) == 1
+        self._teardown(scheduler)
+
+    def test_at_weekly_preset_registered(self, scheduler):
+        scheduler.bot.config.add_section("Scheduled_Messages")
+        scheduler.bot.config.set(
+            "Scheduled_Messages", "@weekly", "alerts: Weekly digest"
+        )
+        self._setup_and_call(scheduler)
+        assert "@weekly" in scheduler.scheduled_messages
+        assert scheduler.scheduled_messages["@weekly"][2] == "@weekly"
+        assert len(scheduler._apscheduler.get_jobs()) == 1
+        self._teardown(scheduler)
+
+    def test_invalid_cron_skipped(self, scheduler):
+        scheduler.bot.config.add_section("Scheduled_Messages")
+        scheduler.bot.config.set(
+            "Scheduled_Messages", "not-a-cron", "general: should not run"
+        )
+        self._setup_and_call(scheduler)
+        assert "not-a-cron" not in scheduler.scheduled_messages
+        # Only non-message jobs (e.g. device-mode) could exist; no scheduled message job
+        msg_jobs = [
+            j
+            for j in scheduler._apscheduler.get_jobs()
+            if j.id.startswith("schedmsg_")
+        ]
+        assert len(msg_jobs) == 0
         self._teardown(scheduler)
 
     def test_invalid_time_format_is_skipped(self, scheduler):
@@ -147,8 +231,9 @@ class TestSetupScheduledMessages:
         scheduler.bot.config.add_section("Scheduled_Messages")
         scheduler.bot.config.set("Scheduled_Messages", "1000", r"general: Line1\nLine2")
         self._setup_and_call(scheduler)
-        _, message = scheduler.scheduled_messages["1000"]
+        _, message, label = scheduler.scheduled_messages["1000"]
         assert "\n" in message
+        assert label == "10:00"
         self._teardown(scheduler)
 
     def test_reload_replaces_existing_jobs(self, scheduler):
@@ -465,18 +550,31 @@ class TestAPSchedulerLifecycle:
         assert scheduler._apscheduler is None
         scheduler.join(timeout=0.1)  # must not raise
 
-    def test_cron_trigger_hour_minute(self, scheduler):
-        """Registered jobs get a CronTrigger with the correct hour/minute."""
+    def test_cron_trigger_hour_minute_legacy_hhmm(self, scheduler):
+        """Legacy HHMM keys produce a CronTrigger with the correct hour/minute."""
         scheduler.bot.config.add_section("Scheduled_Messages")
         scheduler.bot.config.set("Scheduled_Messages", "1430", "ch: hello")
         scheduler.setup_scheduled_messages()
-        jobs = scheduler._apscheduler.get_jobs()
-        assert len(jobs) == 1
-        trigger = jobs[0].trigger
+        msg_jobs = [j for j in scheduler._apscheduler.get_jobs() if j.id.startswith("schedmsg_")]
+        assert len(msg_jobs) == 1
+        trigger = msg_jobs[0].trigger
         # CronTrigger fields: hour=14, minute=30
         field_map = {f.name: f for f in trigger.fields}
         assert str(field_map["hour"]) == "14"
         assert str(field_map["minute"]) == "30"
+        scheduler.join(timeout=1)
+
+    def test_cron_trigger_from_five_field_expression(self, scheduler):
+        """5-field crontab keys produce the expected hour/minute fields."""
+        scheduler.bot.config.add_section("Scheduled_Messages")
+        scheduler.bot.config.set("Scheduled_Messages", "15 10 * * *", "ch: ping")
+        scheduler.setup_scheduled_messages()
+        msg_jobs = [j for j in scheduler._apscheduler.get_jobs() if j.id.startswith("schedmsg_")]
+        assert len(msg_jobs) == 1
+        trigger = msg_jobs[0].trigger
+        field_map = {f.name: f for f in trigger.fields}
+        assert str(field_map["hour"]) == "10"
+        assert str(field_map["minute"]) == "15"
         scheduler.join(timeout=1)
 
 

--- a/tests/test_scheduler_logic.py
+++ b/tests/test_scheduler_logic.py
@@ -140,7 +140,8 @@ class TestSetupScheduledMessages:
         scheduler.bot.config.set("Scheduled_Messages", "0900", "general: Good morning!")
         self._setup_and_call(scheduler)
         assert "0900" in scheduler.scheduled_messages
-        channel, message, label = scheduler.scheduled_messages["0900"]
+        channel, message, label, scope = scheduler.scheduled_messages["0900"]
+        assert scope is None
         assert channel == "general"
         assert "Good morning!" in message
         assert label == "09:00"
@@ -163,7 +164,8 @@ class TestSetupScheduledMessages:
         )
         self._setup_and_call(scheduler)
         assert "0 9 * * *" in scheduler.scheduled_messages
-        ch, msg, label = scheduler.scheduled_messages["0 9 * * *"]
+        ch, msg, label, _scope = scheduler.scheduled_messages["0 9 * * *"]
+        assert _scope is None
         assert ch == "general"
         assert "Morning cron" in msg
         assert label == "0 9 * * *"
@@ -171,7 +173,27 @@ class TestSetupScheduledMessages:
         msg_jobs = [
             j for j in scheduler._apscheduler.get_jobs() if j.id.startswith("schedmsg_")
         ]
-        assert msg_jobs[0].kwargs == {"schedule_key": "0 9 * * *"}
+        assert msg_jobs[0].kwargs == {"schedule_key": "0 9 * * *", "scope": None}
+        self._teardown(scheduler)
+
+    def test_scoped_flood_message_stores_scope_and_job_kwargs(self, scheduler):
+        scheduler.bot.config.add_section("Scheduled_Messages")
+        scheduler.bot.config.set(
+            "Scheduled_Messages",
+            "0 18 * * *",
+            "Public:#sea:Hello! Come send test messages.",
+        )
+        self._setup_and_call(scheduler)
+        assert "0 18 * * *" in scheduler.scheduled_messages
+        ch, msg, label, scope = scheduler.scheduled_messages["0 18 * * *"]
+        assert ch == "Public"
+        assert scope == "#sea"
+        assert msg.startswith("Hello!")
+        msg_jobs = [
+            j for j in scheduler._apscheduler.get_jobs() if j.id.startswith("schedmsg_")
+        ]
+        assert len(msg_jobs) == 1
+        assert msg_jobs[0].kwargs == {"schedule_key": "0 18 * * *", "scope": "#sea"}
         self._teardown(scheduler)
 
     def test_at_weekly_preset_registered(self, scheduler):
@@ -236,7 +258,8 @@ class TestSetupScheduledMessages:
         scheduler.bot.config.add_section("Scheduled_Messages")
         scheduler.bot.config.set("Scheduled_Messages", "1000", r"general: Line1\nLine2")
         self._setup_and_call(scheduler)
-        _, message, label = scheduler.scheduled_messages["1000"]
+        _, message, label, _sc = scheduler.scheduled_messages["1000"]
+        assert _sc is None
         assert "\n" in message
         assert label == "10:00"
         self._teardown(scheduler)
@@ -987,7 +1010,7 @@ class TestSendScheduledMessageAsync:
         scheduler.bot.command_manager.send_channel_message = AsyncMock()
         asyncio.run(scheduler._send_scheduled_message_async("general", "Hello world"))
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "general", "Hello world", skip_user_rate_limit=True
+            "general", "Hello world", skip_user_rate_limit=True, scope=None
         )
 
     def test_with_placeholder_calls_get_mesh_info_and_formats(self):
@@ -1024,7 +1047,7 @@ class TestSendScheduledMessageAsync:
                 )
         mock_fmt.assert_called_once()
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "general", "Contacts: 42", skip_user_rate_limit=True
+            "general", "Contacts: 42", skip_user_rate_limit=True, scope=None
         )
 
     def test_get_mesh_info_exception_sends_message_as_is(self):
@@ -1042,7 +1065,7 @@ class TestSendScheduledMessageAsync:
                 )
             )
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "general", "Active: {total_contacts}", skip_user_rate_limit=True
+            "general", "Active: {total_contacts}", skip_user_rate_limit=True, scope=None
         )
 
     def test_format_placeholder_exception_sends_message_as_is(self):
@@ -1064,7 +1087,19 @@ class TestSendScheduledMessageAsync:
                     )
                 )
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "alerts", "Count: {total_contacts}", skip_user_rate_limit=True
+            "alerts", "Count: {total_contacts}", skip_user_rate_limit=True, scope=None
+        )
+
+    def test_passes_scope_to_send_channel_message(self):
+        scheduler = _make_scheduler()
+        scheduler.bot.command_manager.send_channel_message = AsyncMock()
+        asyncio.run(
+            scheduler._send_scheduled_message_async(
+                "Public", "Hi", scope="#sea"
+            )
+        )
+        scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
+            "Public", "Hi", skip_user_rate_limit=True, scope="#sea"
         )
 
     def test_stagger_invokes_sleep_when_configured(self):
@@ -1140,7 +1175,13 @@ class TestSendScheduledMessageWrapper:
 
         mock_loop = Mock()
 
-        async def _fake_send(channel: str, message: str, *, schedule_key: str = "") -> None:
+        async def _fake_send(
+            channel: str,
+            message: str,
+            *,
+            schedule_key: str = "",
+            scope: str | None = None,
+        ) -> None:
             return None
 
         def _run_until_complete(coro):
@@ -1156,7 +1197,9 @@ class TestSendScheduledMessageWrapper:
 
         mock_loop.run_until_complete.assert_called_once()
         mock_loop.close.assert_called_once()
-        mock_send.assert_called_once_with("general", "test message", schedule_key="")
+        mock_send.assert_called_once_with(
+            "general", "test message", schedule_key="", scope=None
+        )
 
     def test_suppressed_when_radio_zombie(self):
         scheduler = _make_scheduler()
@@ -1574,7 +1617,7 @@ class TestSendScheduledMessageAsyncTimeout:
         asyncio.run(sched._send_scheduled_message_async("#general", "hello"))
 
         sched.bot.command_manager.send_channel_message.assert_awaited_once_with(
-            "#general", "hello", skip_user_rate_limit=True
+            "#general", "hello", skip_user_rate_limit=True, scope=None
         )
 
     def test_timeout_raises_asyncio_timeout_error(self, mock_logger):

--- a/tests/test_scheduler_logic.py
+++ b/tests/test_scheduler_logic.py
@@ -20,6 +20,7 @@ def scheduler(mock_logger):
     bot.logger = mock_logger
     bot.config = ConfigParser()
     bot.config.add_section("Bot")
+    bot.config.set("Bot", "scheduled_message_max_stagger_seconds", "0")
     return MessageScheduler(bot)
 
 
@@ -167,6 +168,10 @@ class TestSetupScheduledMessages:
         assert "Morning cron" in msg
         assert label == "0 9 * * *"
         assert len(scheduler._apscheduler.get_jobs()) == 1
+        msg_jobs = [
+            j for j in scheduler._apscheduler.get_jobs() if j.id.startswith("schedmsg_")
+        ]
+        assert msg_jobs[0].kwargs == {"schedule_key": "0 9 * * *"}
         self._teardown(scheduler)
 
     def test_at_weekly_preset_registered(self, scheduler):
@@ -816,6 +821,7 @@ def _make_scheduler():
     config = _configparser.ConfigParser()
     config.add_section("Bot")
     config.set("Bot", "advert_interval_hours", "0")
+    config.set("Bot", "scheduled_message_max_stagger_seconds", "0")
     bot.config = config
     bot.main_event_loop = None
     bot.is_radio_zombie = False
@@ -981,7 +987,7 @@ class TestSendScheduledMessageAsync:
         scheduler.bot.command_manager.send_channel_message = AsyncMock()
         asyncio.run(scheduler._send_scheduled_message_async("general", "Hello world"))
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "general", "Hello world"
+            "general", "Hello world", skip_user_rate_limit=True
         )
 
     def test_with_placeholder_calls_get_mesh_info_and_formats(self):
@@ -1018,7 +1024,7 @@ class TestSendScheduledMessageAsync:
                 )
         mock_fmt.assert_called_once()
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "general", "Contacts: 42"
+            "general", "Contacts: 42", skip_user_rate_limit=True
         )
 
     def test_get_mesh_info_exception_sends_message_as_is(self):
@@ -1036,7 +1042,7 @@ class TestSendScheduledMessageAsync:
                 )
             )
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "general", "Active: {total_contacts}"
+            "general", "Active: {total_contacts}", skip_user_rate_limit=True
         )
 
     def test_format_placeholder_exception_sends_message_as_is(self):
@@ -1058,8 +1064,29 @@ class TestSendScheduledMessageAsync:
                     )
                 )
         scheduler.bot.command_manager.send_channel_message.assert_called_once_with(
-            "alerts", "Count: {total_contacts}"
+            "alerts", "Count: {total_contacts}", skip_user_rate_limit=True
         )
+
+    def test_stagger_invokes_sleep_when_configured(self):
+        """Nonzero scheduled_message_max_stagger_seconds yields await sleep in [0, max)."""
+        scheduler = _make_scheduler()
+        scheduler.bot.config.set("Bot", "scheduled_message_max_stagger_seconds", "100")
+        scheduler.bot.command_manager.send_channel_message = AsyncMock()
+        with patch("modules.scheduler.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            asyncio.run(
+                scheduler._send_scheduled_message_async("g", "m", schedule_key="0 8 * * *")
+            )
+        mock_sleep.assert_called_once()
+        delay = mock_sleep.call_args[0][0]
+        assert 0 <= delay < 100
+
+    def test_stagger_seconds_deterministic_for_same_key(self):
+        scheduler = _make_scheduler()
+        scheduler.bot.config.set("Bot", "scheduled_message_max_stagger_seconds", "10")
+        a = scheduler._scheduled_message_stagger_seconds("0 8 * * 2")
+        b = scheduler._scheduled_message_stagger_seconds("0 8 * * 2")
+        assert a == b
+        assert 0 <= a < 10
 
 
 # ---------------------------------------------------------------------------
@@ -1113,7 +1140,7 @@ class TestSendScheduledMessageWrapper:
 
         mock_loop = Mock()
 
-        async def _fake_send(channel: str, message: str) -> None:
+        async def _fake_send(channel: str, message: str, *, schedule_key: str = "") -> None:
             return None
 
         def _run_until_complete(coro):
@@ -1129,7 +1156,7 @@ class TestSendScheduledMessageWrapper:
 
         mock_loop.run_until_complete.assert_called_once()
         mock_loop.close.assert_called_once()
-        mock_send.assert_called_once_with("general", "test message")
+        mock_send.assert_called_once_with("general", "test message", schedule_key="")
 
     def test_suppressed_when_radio_zombie(self):
         scheduler = _make_scheduler()
@@ -1437,6 +1464,7 @@ def _make_sched_with_logger(mock_logger):
     bot.logger = mock_logger
     bot.config = ConfigParser()
     bot.config.add_section("Bot")
+    bot.config.set("Bot", "scheduled_message_max_stagger_seconds", "0")
     bot.is_radio_zombie = False   # ensure zombie guard does not suppress sends
     bot.is_radio_offline = False  # ensure offline guard does not suppress sends
     return MessageScheduler(bot)
@@ -1546,7 +1574,7 @@ class TestSendScheduledMessageAsyncTimeout:
         asyncio.run(sched._send_scheduled_message_async("#general", "hello"))
 
         sched.bot.command_manager.send_channel_message.assert_awaited_once_with(
-            "#general", "hello"
+            "#general", "hello", skip_user_rate_limit=True
         )
 
     def test_timeout_raises_asyncio_timeout_error(self, mock_logger):

--- a/tests/test_scheduler_logic.py
+++ b/tests/test_scheduler_logic.py
@@ -2,10 +2,9 @@
 
 import datetime
 import time
-from zoneinfo import ZoneInfo
-
 from configparser import ConfigParser
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
 

--- a/tests/test_webhook_service.py
+++ b/tests/test_webhook_service.py
@@ -224,6 +224,34 @@ class TestHandleWebhookDispatch:
         assert call_args[0][1] == "Hi Alice!"
 
     @pytest.mark.asyncio
+    async def test_flood_scope_in_body_passed_to_send(self, mock_logger):
+        svc, bot = _make_service(mock_logger)
+        req = _make_request(
+            body={"channel": "general", "message": "Hello!", "flood_scope": "west"}
+        )
+        await svc._handle_webhook(req)
+        _, kwargs = bot.command_manager.send_channel_message.call_args
+        assert kwargs.get("scope") == "#west"
+
+    @pytest.mark.asyncio
+    async def test_flood_scope_null_falls_back_to_config(self, mock_logger):
+        svc, bot = _make_service(mock_logger, {"flood_scope": "#sea"})
+        req = _make_request(
+            body={"channel": "general", "message": "Hello!", "flood_scope": None}
+        )
+        await svc._handle_webhook(req)
+        _, kwargs = bot.command_manager.send_channel_message.call_args
+        assert kwargs.get("scope") == "#sea"
+
+    @pytest.mark.asyncio
+    async def test_config_flood_scope_used_when_body_omits_it(self, mock_logger):
+        svc, bot = _make_service(mock_logger, {"flood_scope": "#sea"})
+        req = _make_request(body={"channel": "general", "message": "Hello!"})
+        await svc._handle_webhook(req)
+        _, kwargs = bot.command_manager.send_channel_message.call_args
+        assert kwargs.get("scope") == "#sea"
+
+    @pytest.mark.asyncio
     async def test_long_message_truncated(self, mock_logger):
         svc, bot = _make_service(mock_logger, {"max_message_length": "10"})
         long_msg = "A" * 100

--- a/tests/unit/test_darc_mowas.py
+++ b/tests/unit/test_darc_mowas.py
@@ -3,12 +3,16 @@
 Unit tests for DARC MoWaS CAP alert parsing
 """
 
+import asyncio
+import configparser
 import xml.dom.minidom
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from modules.service_plugins.darc_mowas_service import (
+    DARC_MoWaS_Service,
     TRDECapAlert,
     TRDECapAlertArea,
     TRDECapAlertInfo,
@@ -113,3 +117,49 @@ class TestMoWaSAlertParsing:
         assert isinstance(area, TRDECapAlertArea)
         assert area.areaDesc == "Deutschland"
         assert ("SHN", "100000000000") in area.geocode
+
+
+def _mowas_service_bot():
+    bot = MagicMock()
+    bot.logger = MagicMock()
+    cfg = configparser.ConfigParser()
+    cfg.add_section("DARC_MoWaS_Service")
+    bot.config = cfg
+    return bot
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_chunks_assigns_ascending_timestamps_per_index():
+    """Each chunk gets ts_now + i seconds so clients can order and dedupe."""
+    svc = DARC_MoWaS_Service(_mowas_service_bot())
+    captured: list[tuple[int, datetime]] = []
+
+    async def capture(channel, chunk, index, total, timestamp):
+        captured.append((index, timestamp))
+
+    svc._send_chunk_with_retry = capture  # type: ignore[method-assign]
+
+    pending: list[asyncio.Task] = []
+    real_create_task = asyncio.create_task
+
+    def schedule(coro):
+        task = real_create_task(coro)
+        pending.append(task)
+        return task
+
+    with patch(
+        "modules.service_plugins.darc_mowas_service.asyncio.create_task",
+        side_effect=schedule,
+    ):
+        await svc._send_chunks("mowas", ["a", "b", "c"])
+
+    await asyncio.gather(*pending)
+
+    assert len(captured) == 3
+    captured.sort(key=lambda x: x[0])
+    timestamps = [ts for _, ts in captured]
+    assert timestamps == sorted(timestamps)
+    assert len(set(timestamps)) == 3
+    for i in range(1, len(timestamps)):
+        assert timestamps[i] - timestamps[i - 1] == timedelta(seconds=1)

--- a/tests/unit/test_flood_scope_resolve.py
+++ b/tests/unit/test_flood_scope_resolve.py
@@ -1,0 +1,123 @@
+"""Unit tests for outbound flood scope resolution."""
+
+import configparser
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from modules.command_manager import CommandManager
+from modules.models import MeshMessage
+from modules.service_plugins.base_service import BaseServicePlugin
+
+
+def _make_config(**channels_opts: str) -> configparser.ConfigParser:
+    config = configparser.ConfigParser()
+    config.add_section("Channels")
+    for key, val in channels_opts.items():
+        config.set("Channels", key, val)
+    return config
+
+
+def _command_manager(config: configparser.ConfigParser) -> CommandManager:
+    bot = MagicMock()
+    bot.config = config
+    bot.logger = Mock()
+    cm = object.__new__(CommandManager)
+    cm.bot = bot
+    cm.logger = bot.logger
+    cm.flood_scope_allow_global = False
+    cm.flood_scope_keys = {}
+    return cm
+
+
+class TestResolveChannelSendScope:
+    def test_explicit_scope_wins(self):
+        cm = _command_manager(_make_config())
+        assert cm.resolve_channel_send_scope(scope="#west") == "#west"
+
+    def test_message_reply_scope_when_scope_arg_none(self):
+        cm = _command_manager(_make_config())
+        msg = MeshMessage(content="x", channel="general", is_dm=False, reply_scope="#east")
+        assert cm.resolve_channel_send_scope(scope=None, message=msg) == "#east"
+
+    def test_config_section_flood_scope(self):
+        config = configparser.ConfigParser()
+        config.add_section("Channels")
+        config.add_section("Weather_Service")
+        config.set("Weather_Service", "flood_scope", "west")
+        cm = _command_manager(config)
+        assert cm.resolve_channel_send_scope(
+            scope=None, config_section="Weather_Service"
+        ) == "#west"
+
+    def test_returns_none_for_override_fallback(self):
+        cm = _command_manager(_make_config(outgoing_flood_scope_override="#west"))
+        assert cm.resolve_channel_send_scope(scope=None) is None
+
+    def test_precedence_explicit_over_message(self):
+        cm = _command_manager(_make_config())
+        msg = MeshMessage(content="x", channel="general", is_dm=False, reply_scope="#east")
+        assert cm.resolve_channel_send_scope(scope="#west", message=msg) == "#west"
+
+
+class _StubService(BaseServicePlugin):
+    config_section = "Weather_Service"
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+
+class TestGetMeshFloodScope:
+    def test_reads_and_normalizes_section_key(self):
+        config = configparser.ConfigParser()
+        config.add_section("Weather_Service")
+        config.set("Weather_Service", "flood_scope", "#sea")
+        bot = MagicMock()
+        bot.config = config
+        bot.logger = Mock()
+        svc = _StubService(bot)
+        assert svc.get_mesh_flood_scope() == "#sea"
+
+    def test_empty_returns_none(self):
+        config = configparser.ConfigParser()
+        config.add_section("Weather_Service")
+        bot = MagicMock()
+        bot.config = config
+        bot.logger = Mock()
+        svc = _StubService(bot)
+        assert svc.get_mesh_flood_scope() is None
+
+
+@pytest.mark.asyncio
+async def test_send_channel_message_applies_override_when_resolve_returns_none():
+    config = _make_config(outgoing_flood_scope_override="west")
+    bot = MagicMock()
+    bot.config = config
+    bot.logger = Mock()
+    bot.connected = True
+    bot.is_radio_zombie = False
+    bot.is_radio_offline = False
+    bot.channel_manager.get_channel_number.return_value = 1
+
+    set_flood_scope = AsyncMock(return_value=MagicMock(type="OK"))
+    send_chan_msg = AsyncMock(return_value=MagicMock(type="OK", payload={}))
+    bot.meshcore = MagicMock()
+    bot.meshcore.commands.set_flood_scope = set_flood_scope
+    bot.meshcore.commands.send_chan_msg = send_chan_msg
+
+    cm = object.__new__(CommandManager)
+    cm.bot = bot
+    cm.logger = bot.logger
+    cm.flood_scope_allow_global = False
+    cm.flood_scope_keys = {}
+    cm._check_rate_limits = AsyncMock(return_value=(True, None))
+    cm._handle_send_result = MagicMock(return_value=True)
+    cm._is_no_event_received = MagicMock(return_value=False)
+
+    await cm.send_channel_message("general", "hi", scope=None)
+
+    set_flood_scope.assert_awaited()
+    assert set_flood_scope.await_args_list[0].args[0] == "#west"

--- a/tests/unit/test_packet_capture_mqtt_jwt_config.py
+++ b/tests/unit/test_packet_capture_mqtt_jwt_config.py
@@ -1,0 +1,126 @@
+"""PacketCapture MQTT broker JWT renewal interval and TTL parsing."""
+
+from __future__ import annotations
+
+import configparser
+from unittest.mock import MagicMock
+
+import pytest
+
+from modules.service_plugins.packet_capture_service import PacketCaptureService
+
+
+def _bot_from_ini(ini: str) -> MagicMock:
+    cp = configparser.ConfigParser()
+    cp.read_string(ini.strip())
+    bot = MagicMock()
+    bot.config = cp
+    return bot
+
+
+def test_parse_mqtt_brokers_defaults_renewal_and_ttl():
+    bot = _bot_from_ini(
+        """
+        [PacketCapture]
+        enabled = false
+        mqtt1_server = broker.example
+        """
+    )
+    svc = object.__new__(PacketCaptureService)
+    svc.bot = bot
+    brokers = PacketCaptureService._parse_mqtt_brokers(svc, bot.config)
+    assert len(brokers) == 1
+    assert brokers[0]["jwt_renewal_interval"] == 43200
+    assert brokers[0]["jwt_ttl_seconds"] == 86400
+
+
+def test_parse_mqtt_brokers_global_overrides():
+    bot = _bot_from_ini(
+        """
+        [PacketCapture]
+        enabled = false
+        jwt_renewal_interval = 7200
+        jwt_ttl_seconds = 3600
+        mqtt1_server = a.example
+        mqtt2_server = b.example
+        """
+    )
+    svc = object.__new__(PacketCaptureService)
+    svc.bot = bot
+    brokers = PacketCaptureService._parse_mqtt_brokers(svc, bot.config)
+    assert len(brokers) == 2
+    for b in brokers:
+        assert b["jwt_renewal_interval"] == 7200
+        assert b["jwt_ttl_seconds"] == 3600
+
+
+def test_parse_mqtt_brokers_per_broker_overrides():
+    bot = _bot_from_ini(
+        """
+        [PacketCapture]
+        enabled = false
+        jwt_renewal_interval = 7200
+        jwt_ttl_seconds = 86400
+        mqtt1_server = short-ttl.example
+        mqtt1_jwt_ttl_seconds = 3600
+        mqtt1_jwt_renewal_interval = 1800
+        mqtt2_server = inherit.example
+        """
+    )
+    svc = object.__new__(PacketCaptureService)
+    svc.bot = bot
+    brokers = PacketCaptureService._parse_mqtt_brokers(svc, bot.config)
+    assert len(brokers) == 2
+    assert brokers[0]["host"] == "short-ttl.example"
+    assert brokers[0]["jwt_ttl_seconds"] == 3600
+    assert brokers[0]["jwt_renewal_interval"] == 1800
+    assert brokers[1]["jwt_ttl_seconds"] == 86400
+    assert brokers[1]["jwt_renewal_interval"] == 7200
+
+
+def test_parse_mqtt_brokers_renewal_zero_override():
+    bot = _bot_from_ini(
+        """
+        [PacketCapture]
+        enabled = false
+        jwt_renewal_interval = 3600
+        mqtt1_server = no-renew.example
+        mqtt1_jwt_renewal_interval = 0
+        """
+    )
+    svc = object.__new__(PacketCaptureService)
+    svc.bot = bot
+    brokers = PacketCaptureService._parse_mqtt_brokers(svc, bot.config)
+    assert brokers[0]["jwt_renewal_interval"] == 0
+
+
+def test_auth_token_iat_exp_clamps_non_positive_ttl():
+    svc = object.__new__(PacketCaptureService)
+    svc.jwt_ttl_seconds = 7200
+    iat, exp = PacketCaptureService._auth_token_iat_exp(svc, {"jwt_ttl_seconds": 0})
+    assert exp - iat == 86400
+    assert exp == iat + 86400
+
+    iat2, exp2 = PacketCaptureService._auth_token_iat_exp(svc, {"jwt_ttl_seconds": -10})
+    assert exp2 - iat2 == 86400
+
+
+def test_auth_token_iat_exp_uses_broker_then_global():
+    svc = object.__new__(PacketCaptureService)
+    svc.jwt_ttl_seconds = 999
+    iat, exp = PacketCaptureService._auth_token_iat_exp(svc, {"jwt_ttl_seconds": 120})
+    assert exp - iat == 120
+
+
+@pytest.mark.parametrize(
+    "ttl,phrase",
+    [
+        (3600, "1 hour"),
+        (7200, "2 hours"),
+        (60, "1 minute"),
+        (180, "3 minutes"),
+        (90, "90s"),
+    ],
+)
+def test_jwt_ttl_log_phrase(ttl: int, phrase: str):
+    assert PacketCaptureService._jwt_ttl_log_phrase(ttl) == phrase

--- a/tests/unit/test_path_command_multibyte.py
+++ b/tests/unit/test_path_command_multibyte.py
@@ -4,6 +4,8 @@ Unit tests for PathCommand multi-byte path support: routing_info usage and comma
 """
 
 
+from unittest.mock import MagicMock, Mock
+
 import pytest
 
 from modules.commands.path_command import PathCommand
@@ -145,3 +147,78 @@ class TestPathCommandExtractPathUsesRoutingInfo:
         path_command.translate = lambda key, **kwargs: "Direct connection" if "direct" in key.lower() else key
         result = await path_command._extract_path_from_recent_messages()
         assert "direct" in result.lower()
+
+
+@pytest.mark.unit
+class TestPathCommandMinimumPathBytes:
+    """minimum_path_bytes gates repeater lookup (not command execution)."""
+
+    @pytest.fixture
+    def path_command(self, mock_bot):
+        mock_bot.translator = MagicMock()
+
+        def _translate(key, **kwargs):
+            if key == "commands.path.repeater_resolution_deferred":
+                return f"Path: {kwargs['path']}\n\nTip:{kwargs['minimum_path_bytes']}"
+            return key
+
+        mock_bot.translator.translate = Mock(side_effect=_translate)
+        return PathCommand(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_skips_lookup_when_hops_shorter_than_minimum(self, path_command, mock_bot):
+        path_command.minimum_path_bytes = 2
+        called = []
+
+        async def capture_lookup(node_ids, lookup_func=None):
+            called.append(node_ids)
+            return {}
+
+        path_command._lookup_repeater_names = capture_lookup
+        out = await path_command._decode_path("01,AB")
+        assert called == []
+        assert "01,AB" in out
+        assert "Tip:2" in out
+
+    @pytest.mark.asyncio
+    async def test_runs_lookup_when_hops_meet_minimum(self, path_command, mock_bot):
+        path_command.minimum_path_bytes = 2
+        called = []
+
+        async def capture_lookup(node_ids, lookup_func=None):
+            called.append(list(node_ids))
+            return {nid: {"found": True, "name": "R"} for nid in node_ids}
+
+        path_command._lookup_repeater_names = capture_lookup
+        mock_bot.translator.translate = Mock(
+            side_effect=lambda key, **kwargs: (
+                f"{kwargs['node_id']}: {kwargs['name']}" if key == "commands.path.node_format" else key
+            )
+        )
+        out = await path_command._decode_path("0102,ABCD")
+        assert called == [["0102", "ABCD"]]
+        assert "0102" in out
+
+    @pytest.mark.asyncio
+    async def test_routing_info_bytes_per_hop_authoritative(self, path_command, mock_bot):
+        """bytes_per_hop=1 in packet forces deferred even if node strings are wide (should not happen on wire)."""
+        path_command.minimum_path_bytes = 2
+        called = []
+
+        async def capture_lookup(node_ids, lookup_func=None):
+            called.append(True)
+            return {}
+
+        path_command._lookup_repeater_names = capture_lookup
+        path_command._current_message = MeshMessage(
+            content="path",
+            routing_info={
+                "path_length": 1,
+                "path_nodes": ["0102"],
+                "bytes_per_hop": 1,
+            },
+        )
+        out = await path_command._extract_path_from_recent_messages()
+        assert called == []
+        assert "0102" in out
+        assert "Tip:2" in out

--- a/tests/unit/test_path_command_utf8_message_limits.py
+++ b/tests/unit/test_path_command_utf8_message_limits.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Unit tests for PathCommand UTF-8 byte truncation and multi-message splitting (PR #128)."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -94,6 +94,45 @@ class TestPathCommandSendPathResponseByteSplitting:
         with patch("modules.commands.path_command.asyncio.sleep", new_callable=AsyncMock):
             await path_cmd._send_path_response(msg, response)
         path_cmd.send_response.assert_awaited_once()
+
+
+@pytest.mark.unit
+class TestPathCommandReplyPrefix:
+    """reply_prefix prepended to first RF payload only; last_response includes prefix."""
+
+    @pytest.fixture
+    def path_cmd(self, mock_bot):
+        mock_bot.translator = MagicMock()
+        mock_bot.translator.translate = Mock(side_effect=lambda key, **kwargs: key)
+        cmd = PathCommand(mock_bot)
+        cmd.send_response = AsyncMock(return_value=True)
+        return cmd
+
+    @pytest.mark.asyncio
+    async def test_prepends_prefix_to_single_send(self, path_cmd, mock_bot):
+        path_cmd.path_reply_prefix = "[{sender}]"
+        path_cmd.get_max_message_length = lambda _msg: 200
+        msg = MeshMessage(content="path", channel="general", is_dm=False, sender_id="alice")
+        await path_cmd._send_path_response(msg, "line1")
+        path_cmd.send_response.assert_awaited_once()
+        payload = path_cmd.send_response.call_args[0][1]
+        assert payload == "[alice]\nline1"
+        assert path_cmd.last_response == "[alice]\nline1"
+
+    @pytest.mark.asyncio
+    async def test_prefix_only_on_first_split_message(self, path_cmd, mock_bot):
+        path_cmd.path_reply_prefix = "P:"
+        path_cmd.get_max_message_length = lambda _msg: 25
+        path_cmd.translate = MockTranslateForSend()
+        msg = MeshMessage(content="path", channel="general", is_dm=False)
+        response = "a" * 12 + "\n" + "b" * 13
+        with patch("modules.commands.path_command.asyncio.sleep", new_callable=AsyncMock):
+            await path_cmd._send_path_response(msg, response)
+        assert path_cmd.send_response.await_count >= 2
+        first = path_cmd.send_response.call_args_list[0][0][1]
+        assert first.startswith("P:\n")
+        second = path_cmd.send_response.call_args_list[1][0][1]
+        assert not second.startswith("P:\n")
 
 
 class MockTranslateForSend:

--- a/tests/unit/test_response_template.py
+++ b/tests/unit/test_response_template.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Unit tests for piped response templates and message_path_bytes_per_hop."""
+
+import configparser
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from modules.commands.test_command import TestCommand as MeshTestCommand
+from modules.models import MeshMessage
+from modules.response_template import format_piped_template
+from modules.utils import message_path_bytes_per_hop
+
+
+@pytest.mark.unit
+def test_message_path_bytes_per_hop_from_routing():
+    msg = MeshMessage(
+        content="test",
+        channel="c",
+        routing_info={"bytes_per_hop": 2, "path_length": 1, "path_nodes": ["0102"]},
+    )
+    assert message_path_bytes_per_hop(msg) == 2
+
+
+@pytest.mark.unit
+def test_message_path_bytes_per_hop_infers_from_nodes():
+    msg = MeshMessage(
+        content="test",
+        channel="c",
+        path="01,02,03 (3 hops)",
+        routing_info=None,
+    )
+    assert message_path_bytes_per_hop(msg) == 1
+
+
+@pytest.mark.unit
+def test_format_piped_template_plain_field():
+    out = format_piped_template("a={x}|end", {"x": "hi"}, message=None)
+    assert out == "a=hi|end"
+
+
+@pytest.mark.unit
+def test_pathbytes_min_clears_when_below_threshold():
+    msg = MeshMessage(
+        content="test",
+        channel="c",
+        routing_info={"bytes_per_hop": 1, "path_length": 2, "path_nodes": ["01", "02"]},
+    )
+    out = format_piped_template(
+        "d={path_distance|pathbytes_min:2}",
+        {"path_distance": "10.0km (1 segs)"},
+        message=msg,
+    )
+    assert out == "d="
+
+
+@pytest.mark.unit
+def test_pathbytes_min_keeps_multibyte():
+    msg = MeshMessage(
+        content="test",
+        channel="c",
+        routing_info={"bytes_per_hop": 2, "path_length": 1, "path_nodes": ["0102"]},
+    )
+    out = format_piped_template(
+        "d={path_distance|pathbytes:2}",
+        {"path_distance": "5.0km (1 segs)"},
+        message=msg,
+    )
+    assert out == "d=5.0km (1 segs)"
+
+
+@pytest.mark.unit
+def test_prefix_if_nonempty_literal_may_contain_pipe():
+    """Regression: args like ' | Path Dist: ' must not split into a fake 'Path Dist' filter."""
+    msg = MeshMessage(
+        content="test",
+        channel="c",
+        routing_info={"bytes_per_hop": 2, "path_length": 1, "path_nodes": ["0102"]},
+    )
+    out = format_piped_template(
+        "x={path_distance|pathbytes_min:2|prefix_if_nonempty: | Path Dist: }",
+        {"path_distance": "1km"},
+        message=msg,
+        logger=None,
+    )
+    assert out == "x= | Path Dist: 1km"
+
+
+@pytest.mark.unit
+def test_get_response_format_test_command_over_keywords():
+    bot = MagicMock()
+    bot.logger = Mock()
+    bot.config = configparser.ConfigParser()
+    bot.config.add_section("Bot")
+    bot.config.set("Bot", "bot_name", "TestBot")
+    bot.config.add_section("Channels")
+    bot.config.set("Channels", "monitor_channels", "general")
+    bot.config.set("Channels", "respond_to_dms", "true")
+    bot.config.add_section("Keywords")
+    bot.config.set("Keywords", "test", "from-keywords")
+    bot.config.add_section("Test_Command")
+    bot.config.set("Test_Command", "enabled", "true")
+    bot.config.set("Test_Command", "response_format", "from-test-cmd")
+    bot.config.add_section("Path_Command")
+    bot.config.set("Path_Command", "recency_weight", "0.2")
+    bot.translator = MagicMock()
+    bot.translator.translate = Mock(side_effect=lambda key, **kwargs: key)
+    bot.prefix_hex_chars = 2
+
+    cmd = MeshTestCommand(bot)
+    assert cmd.get_response_format() == "from-test-cmd"

--- a/tests/unit/test_scope_matching.py
+++ b/tests/unit/test_scope_matching.py
@@ -85,3 +85,63 @@ def test_different_payload_type_does_not_match():
     tc = make_transport_code("#west", PAYLOAD_TYPE, PAYLOAD)
     result = MessageHandler._match_scope(tc, PAYLOAD_TYPE + 1, PAYLOAD, scope_keys)
     assert result is None
+
+
+def _make_handler_for_scope_resolve():
+    from unittest.mock import MagicMock
+
+    mh = object.__new__(MessageHandler)
+    mh.logger = MagicMock()
+    return mh
+
+
+def test_resolve_reply_scope_uses_decode_when_cache_route_type_wrong():
+    """Stale RF cache (FLOOD) + decoded TC_FLOOD still matches configured scope."""
+    scope_name = "#w-wa"
+    scope_keys = {scope_name: _scope_key(scope_name)}
+    tc = make_transport_code(scope_name, PAYLOAD_TYPE, PAYLOAD)
+    packet_info = {
+        "route_type": 0,
+        "transport_codes": {"code1": tc, "code2": 0},
+        "payload_type": PAYLOAD_TYPE,
+        "payload_hex": PAYLOAD.hex(),
+    }
+    recent_rf_data = {
+        "route_type_int": 1,
+        "transport_code1": None,
+        "payload_type_int": PAYLOAD_TYPE,
+        "scope_payload_hex": "",
+    }
+    mh = _make_handler_for_scope_resolve()
+    assert mh._resolve_reply_scope_from_rf_data(recent_rf_data, packet_info, scope_keys) == scope_name
+    mh.logger.debug.assert_any_call(
+        "TC_FLOOD scope fields from packet decode (cache had route_type=%s tc=%s)",
+        1,
+        None,
+    )
+
+
+def test_effective_route_type_prefers_decode_tc_flood():
+    mh = _make_handler_for_scope_resolve()
+    recent_rf_data = {"route_type_int": 1}
+    packet_info = {"route_type": 0, "transport_codes": {"code1": 1}}
+    assert mh._effective_route_type_int(recent_rf_data, packet_info) == 0
+
+
+def test_scope_fields_from_packet_info_enum_route_type():
+    class _EnumVal:
+        def __init__(self, value: int):
+            self.value = value
+
+    rt, tc, pt, hx = MessageHandler._scope_fields_from_packet_info(
+        {
+            "route_type": _EnumVal(0),
+            "payload_type": _EnumVal(PAYLOAD_TYPE),
+            "transport_codes": {"code1": 42},
+            "payload_hex": PAYLOAD.hex(),
+        }
+    )
+    assert rt == 0
+    assert tc == 42
+    assert pt == PAYLOAD_TYPE
+    assert hx == PAYLOAD.hex()

--- a/translations/de.json
+++ b/translations/de.json
@@ -357,7 +357,8 @@
             "continuation_start": "...\n{line}",
             "continuation_end": "\n...",
             "truncation": "...",
-            "unknown_name": "Unbekannt"
+            "unknown_name": "Unbekannt",
+            "repeater_resolution_deferred": "Pfad: {path}\n\n💡 Hinweis: Repeater-Erkennung erfordert Pfade mit {minimum_path_bytes} Byte(s) pro Hop."
         },
         "prefix": {
             "description": "Repeater nach zweistelligem Präfix suchen (z.B. 'prefix 1A')",

--- a/translations/en-GB.json
+++ b/translations/en-GB.json
@@ -337,7 +337,8 @@
       "continuation_start": "...\n{line}",
       "continuation_end": "\n...",
       "truncation": "...",
-      "unknown_name": "Unknown"
+      "unknown_name": "Unknown",
+      "repeater_resolution_deferred": "Path: {path}\n\n💡 Tip: Repeater identification requires {minimum_path_bytes}-byte paths."
     },
     "prefix": {
       "description": "Look up repeaters by two-character prefix (e.g., 'prefix 1A')",

--- a/translations/en.json
+++ b/translations/en.json
@@ -271,7 +271,8 @@
       "continuation_start": "...\n{line}",
       "continuation_end": "\n...",
       "truncation": "...",
-      "unknown_name": "Unknown"
+      "unknown_name": "Unknown",
+      "repeater_resolution_deferred": "Path: {path}\n\n💡 Tip: Repeater identification requires {minimum_path_bytes}-byte paths."
     },
     "multitest": {
       "description": "Listens for 6 seconds and collects all unique paths from incoming messages with the same packet hash",

--- a/translations/es.json
+++ b/translations/es.json
@@ -213,7 +213,8 @@
             "continuation_start": "...\n{line}",
             "continuation_end": "\n...",
             "truncation": "...",
-            "unknown_name": "Desconocido"
+            "unknown_name": "Desconocido",
+            "repeater_resolution_deferred": "Ruta: {path}\n\n💡 Consejo: la identificación de repetidores requiere rutas de {minimum_path_bytes} byte(s) por salto."
         },
         "prefix": {
             "description": "Buscar repetidores por prefijo de dos caracteres (ej., 'prefix 1A')",

--- a/translations/fr-CA.json
+++ b/translations/fr-CA.json
@@ -409,7 +409,8 @@
             "continuation_start": "...\n{line}",
             "continuation_end": "\n...",
             "truncation": "...",
-            "unknown_name": "Inconnu"
+            "unknown_name": "Inconnu",
+            "repeater_resolution_deferred": "Chemin : {path}\n\n💡 Astuce : l'identification des répéteurs exige des chemins de {minimum_path_bytes} octet(s) par saut."
         },
         "prefix": {
             "description": "Rechercher des répéteurs par préfixe de deux caractères (ex : 'prefix 1A')",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -337,7 +337,8 @@
             "continuation_start": "...\n{line}",
             "continuation_end": "\n...",
             "truncation": "...",
-            "unknown_name": "Inconnu"
+            "unknown_name": "Inconnu",
+            "repeater_resolution_deferred": "Chemin : {path}\n\n💡 Astuce : l'identification des répéteurs exige des chemins de {minimum_path_bytes} octet(s) par saut."
         },
         "prefix": {
             "description": "Recherche répéteurs par préfixe 2 caractères (ex: 'prefix 1A')",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -337,7 +337,8 @@
             "continuation_start": "...\n{line}",
             "continuation_end": "\n...",
             "truncation": "...",
-            "unknown_name": "Onbekend"
+            "unknown_name": "Onbekend",
+            "repeater_resolution_deferred": "Pad: {path}\n\n💡 Tip: repeateridentificatie vereist paden met {minimum_path_bytes} byte(s) per hop."
         },
         "prefix": {
             "description": "Zoek repeaters op twee-karakter prefix (bijv. 'prefix 1A')",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -214,7 +214,8 @@
       "continuation_start": "...\n{line}",
       "continuation_end": "\n...",
       "truncation": "...",
-      "unknown_name": "Nieznana"
+      "unknown_name": "Nieznana",
+      "repeater_resolution_deferred": "Ścieżka: {path}\n\n💡 Wskazówka: identyfikacja repeaterów wymaga ścieżek z {minimum_path_bytes} bajt(ami) na skok."
     },
     "multitest": {
       "description": "Nasłuchuje 6 sekund aby zebrać unikalne ścieżki z przychodzących wiadomości z tym samym hash'em pakietu",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -334,7 +334,8 @@
             "continuation_start": "...\n{line}",
             "continuation_end": "\n...",
             "truncation": "...",
-            "unknown_name": "Desconhecido"
+            "unknown_name": "Desconhecido",
+            "repeater_resolution_deferred": "Caminho: {path}\n\n💡 Dica: a identificação de repetidores exige caminhos com {minimum_path_bytes} byte(s) por salto."
         },
         "prefix": {
             "description": "Procurar repetidores por prefixo de dois caracteres (ex: 'prefixo 1A')",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -333,7 +333,8 @@
             "continuation_start": "...\n{line}",
             "continuation_end": "\n...",
             "truncation": "...",
-            "unknown_name": "Desconhecido"
+            "unknown_name": "Desconhecido",
+            "repeater_resolution_deferred": "Caminho: {path}\n\n💡 Dica: a identificação de repetidores exige caminhos com {minimum_path_bytes} byte(s) por salto."
         },
         "prefix": {
             "description": "Pesquisar repetidores por prefixo de dois caracteres (ex: 'prefixo 1A')",


### PR DESCRIPTION
## Highlights

- **Regional flood scope** end-to-end: per-service config, scheduled messages, webhook body override, and correct scope on keyword/RandomLine replies.
- **Scheduler overhaul**: 5-field cron and `@` presets (HHMM deprecated), optional per-job `#scope`, stagger for colliding jobs, better concurrency.
- **DARC MoWaS reliability**: bit-identical retransmits with stable timestamps; ascending timestamps on multi-chunk sends.
- **Path & test commands**: optional reply prefix, gated repeater naming by bytes/hop, customizable `test`/`t` templates with pipe filters.

## Features

**Scheduling**
- `[Scheduled_Messages]` supports cron (`0 8 * * *`), presets (`@daily`, `@hourly`, …); legacy `HHMM` still works with a warning. (*Note:* APScheduler Day of Week starts on Monday unlike Vixie cron, so Monday = 0.)
- Per-job regional scope: `channel:#scope:message` (middle field must start with `#`).
- Added optional `scheduled_message_max_stagger_seconds` to spread out jobs that fire at the same time; scheduled sends skip global `rate_limit_seconds` (channel and `bot_tx_rate_limit` still apply).

**Flood scope**
- `CommandManager.resolve_channel_send_scope()` with precedence: explicit arg → `message.reply_scope` → section `flood_scope` → `[Channels] outgoing_flood_scope_override`.
- Optional `flood_scope` on Weather, Earthquake, Webhook, DARC MoWaS, and related services; webhook JSON may include `"flood_scope": "#scope"`.
- Keyword and RandomLine channel replies use `send_response` so incoming regional scope is honored. #178

**Commands**
- **Path**: `reply_prefix` (first chunk only when split) allows you to add `@[{sender}]` or similar to first reply. `minimum_path_bytes` (2/3) defers DB name lookup on paths with single byte path hashes, this is useful to avoid returning inaccurate information in dense meshes with highly duplicated single-byte prefixes.
- **Test**: `[Test_Command] response_format` overrides `[Keywords] test`; pipe filters (`pathbytes_min`, `prefix_if_nonempty`). This enables things like not returning values unless conditions are met. Example that only returns path distance if multibyte paths are used:

```ini
response_format = ack @[{sender}]{phrase_part} | {path}{path_distance|pathbytes_min:2|prefix_if_nonempty: | Path Dist: } | F/L Dist: {firstlast_distance} | Rec: {timestamp}
```

**Packet capture / MQTT**
- Added global `jwt_ttl_seconds` and per-broker `mqttN_jwt_ttl_seconds` / `mqttN_jwt_renewal_interval` for token lifetime vs refresh cadence. This enables JWTs with a TTL shorter than 24 hours.

**DARC MoWaS**
- Retransmissions reuse the original timestamp for network deduplication; chunk sends get `base + index` second timestamps.

**Other**
- `send_channel_message(..., timestamp=...)` for bit-identical channel replays.
- Service display names strip trailing underscores (e.g. `foo_Service` → `foo`, not `foo_`).

---

## Fixes

- **DM routing**: responses use `sender_pubkey` when available (avoids misrouting when display names collide).
- **Scheduler / feeds**: fire-and-forget scheduled processing; feed send lock avoids coroutine pileup; per-feed last-send tracking.
- **Mesh graph**: `flush_needed` flag reduces redundant flush calls and a deadlock risk.
- **Contact adverts**: `track_contact_advertisement` returns structured success/duplicate status for clearer handler logic.
- **DARC MoWaS / webhook**: chunk timestamp ordering; webhook scope resolution cleanup.

---

## Configuration notes

| Area | Action |
|------|--------|
| Scheduled messages | Prefer cron over `HHMM`; use `channel:#scope:body` for regional sends. |
| MQTT brokers with short-lived tokens | Set `jwt_ttl_seconds` and renewal interval **below** TTL per broker. |
| Service Plugins | Add `flood_scope = #region` under the service plugin configuration or use `[Channels] outgoing_flood_scope_override` to set a global outgoing flood scope. |
| Path / test | See `config.ini.example` for `reply_prefix`, `minimum_path_bytes`, and `response_format`. |

---

## Contributors

Thanks to @fmoessbauer for improvements to DARC MoWaS retransmits, channel timestamps, and service name parsing.