### PR TITLE
Fix NEW_CONTACT handling to check the live radio contact list before treating nodes as new

### DIFF
--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -3604,16 +3604,59 @@ class MessageHandler:
 
             # Check if this is a repeater or companion
             if hasattr(self.bot, "repeater_manager"):
+                auto_manage_setting = self.bot.config.get("Bot", "auto_manage_contacts", fallback="false").lower()
+                refreshed_device_contacts = await self.bot.repeater_manager.refresh_device_contacts()
                 is_repeater = self.bot.repeater_manager._is_repeater_device(contact_data)
+                existing_tracking = self.bot.repeater_manager.get_tracked_contact_row(public_key)
+                already_on_device = self.bot.repeater_manager.is_contact_on_device(public_key)
+                known_contact = already_on_device or existing_tracking is not None
 
                 if is_repeater:
-                    # REPEATER: Track directly in SQLite database (no device contact list)
-                    self.logger.info(f"📡 New repeater discovered: {contact_name} - tracking in database only")
+                    if already_on_device:
+                        if existing_tracking:
+                            self.logger.info(
+                                "📡 Known repeater advert: %s already exists in tracking DB and device contacts",
+                                contact_name,
+                            )
+                        else:
+                            self.logger.info(
+                                "📡 Repeater %s already exists in device contacts; syncing into tracking DB",
+                                contact_name,
+                            )
+                    elif existing_tracking:
+                        self.logger.info(
+                            "📡 Known repeater advert: %s exists in tracking DB but not on device; adding to device contacts",
+                            contact_name,
+                        )
+                    else:
+                        self.logger.info(
+                            "📡 New repeater discovered: %s - adding to device contacts and tracking DB",
+                            contact_name,
+                        )
 
                     # Track repeater in complete database with signal info
                     await self.bot.repeater_manager.track_contact_advertisement(
                         contact_data, signal_info, packet_hash=packet_hash
                     )
+
+                    if not already_on_device:
+                        try:
+                            self._ensure_contact_meshcore_path_encoding(contact_data)
+                            added = await self.bot.repeater_manager.add_contact_from_contact_data(
+                                contact_data,
+                                contact_name,
+                                public_key,
+                                contact_kind="repeater",
+                            )
+                            if added:
+                                already_on_device = self.bot.repeater_manager.is_contact_on_device(public_key)
+                            else:
+                                self.logger.warning(
+                                    "Failed to add repeater %s to device contacts after NEW_CONTACT",
+                                    contact_name,
+                                )
+                        except Exception as e:
+                            self.logger.error("Error adding repeater %s to device contacts: %s", contact_name, e)
 
                     # Notify web viewer of new node
                     if (
@@ -3635,16 +3678,44 @@ class MessageHandler:
                     # Check if auto-purge is needed (run after tracking to ensure data is captured)
                     await self.bot.repeater_manager.check_and_auto_purge()
 
-                    self.logger.info(f"✅ Repeater {contact_name} tracked in database - not added to device contacts")
+                    if already_on_device:
+                        self.logger.info(
+                            "✅ Repeater %s is present on device contacts and tracking DB is up to date",
+                            contact_name,
+                        )
+                    else:
+                        self.logger.info(
+                            "✅ Repeater %s tracked in database, but device contact add did not complete",
+                            contact_name,
+                        )
                     return
                 else:
                     # COMPANION: track in DB; device add behaviour depends on auto_manage_contacts
-                    auto_manage_setting = self.bot.config.get("Bot", "auto_manage_contacts", fallback="false").lower()
-                    self.logger.info(
-                        "👤 New companion discovered: %s — auto_manage_contacts=%s",
-                        contact_name,
-                        auto_manage_setting,
-                    )
+                    if already_on_device:
+                        if existing_tracking:
+                            self.logger.info(
+                                "👤 Known companion advert: %s already exists in tracking DB and device contacts — auto_manage_contacts=%s",
+                                contact_name,
+                                auto_manage_setting,
+                            )
+                        else:
+                            self.logger.info(
+                                "👤 Companion %s already exists in device contacts; syncing into tracking DB — auto_manage_contacts=%s",
+                                contact_name,
+                                auto_manage_setting,
+                            )
+                    elif existing_tracking:
+                        self.logger.info(
+                            "👤 Known companion advert: %s exists in tracking DB but not on device — auto_manage_contacts=%s",
+                            contact_name,
+                            auto_manage_setting,
+                        )
+                    else:
+                        self.logger.info(
+                            "👤 New companion discovered: %s — auto_manage_contacts=%s",
+                            contact_name,
+                            auto_manage_setting,
+                        )
 
                     track_result = await self.bot.repeater_manager.track_contact_advertisement(
                         contact_data, signal_info, packet_hash=packet_hash
@@ -3656,10 +3727,35 @@ class MessageHandler:
                             contact_name,
                         )
                     elif auto_manage_setting == "device":
-                        self.logger.info(
-                            "Device mode — companion %s tracked; firmware handles addition; bot may manage capacity",
-                            contact_name,
-                        )
+                        if already_on_device:
+                            self.logger.info(
+                                "Device mode — companion %s is already present on the radio contact DB",
+                                contact_name,
+                            )
+                        else:
+                            self.logger.info(
+                                "Device mode — companion %s is not on the radio contact DB%s; adding it now",
+                                contact_name,
+                                "" if refreshed_device_contacts else " (contact refresh unavailable)",
+                            )
+                            try:
+                                self._ensure_contact_meshcore_path_encoding(contact_data)
+                                ok = await self.bot.repeater_manager.add_contact_from_contact_data(
+                                    contact_data,
+                                    contact_name,
+                                    public_key,
+                                    contact_kind="companion",
+                                )
+                                if ok:
+                                    already_on_device = self.bot.repeater_manager.is_contact_on_device(public_key)
+                                else:
+                                    self.logger.warning(
+                                        "Failed to add companion contact %s to device in device mode",
+                                        contact_name,
+                                    )
+                            except Exception as e:
+                                self.logger.error("Error adding companion %s to device in device mode: %s", contact_name, e)
+
                         status = await self.bot.repeater_manager.get_contact_list_status()
                         if status and status.get("is_near_limit", False):
                             self.logger.warning(
@@ -3669,7 +3765,7 @@ class MessageHandler:
                             await self.bot.repeater_manager.manage_contact_list(auto_cleanup=True)
                         else:
                             self.logger.info(
-                                "New companion %s — contact list has adequate space",
+                                "Companion %s — contact list has adequate space",
                                 contact_name,
                             )
                     elif auto_manage_setting == "bot":
@@ -3677,6 +3773,11 @@ class MessageHandler:
                         if track_result.duplicate_packet:
                             self.logger.debug(
                                 "Skipping add_companion — duplicate packet_hash for %s (already tracked)",
+                                contact_name,
+                            )
+                        elif already_on_device:
+                            self.logger.info(
+                                "Bot mode — companion %s already exists on the radio contact DB; no add needed",
                                 contact_name,
                             )
                         else:
@@ -3718,10 +3819,11 @@ class MessageHandler:
 
                     await self.bot.repeater_manager.check_and_auto_purge()
 
-                    self.bot.repeater_manager.log_purging_action(
-                        "new_contact_discovered",
-                        f"New contact discovered: {contact_name} (key: {public_key[:16]}...)",
-                    )
+                    if not known_contact:
+                        self.bot.repeater_manager.log_purging_action(
+                            "new_contact_discovered",
+                            f"New contact discovered: {contact_name} (key: {public_key[:16]}...)",
+                        )
                     return
 
             # Fallback: Track in database for unknown contact types (no repeater_manager)

--- a/modules/repeater_manager.py
+++ b/modules/repeater_manager.py
@@ -571,12 +571,7 @@ class RepeaterManager:
 
     def _update_currently_tracked_status_on_conn(self, conn, public_key: str):
         """Update the is_currently_tracked flag on an existing connection (no commit)."""
-        is_tracked = False
-        if hasattr(self.bot.meshcore, 'contacts'):
-            for contact_key, contact_data in list(self.bot.meshcore.contacts.items()):
-                if contact_data.get('public_key', contact_key) == public_key:
-                    is_tracked = True
-                    break
+        is_tracked = self.is_contact_on_device(public_key)
         self.db_manager.execute_update_on_connection(
             conn,
             'UPDATE complete_contact_tracking SET is_currently_tracked = ? WHERE public_key = ?',
@@ -586,13 +581,7 @@ class RepeaterManager:
     async def _update_currently_tracked_status(self, public_key: str):
         """Update the is_currently_tracked flag based on device contact list"""
         try:
-            # Check if this repeater is currently in the device's contact list
-            is_tracked = False
-            if hasattr(self.bot.meshcore, 'contacts'):
-                for contact_key, contact_data in list(self.bot.meshcore.contacts.items()):
-                    if contact_data.get('public_key', contact_key) == public_key:
-                        is_tracked = True
-                        break
+            is_tracked = self.is_contact_on_device(public_key)
 
             # Update the flag
             self.db_manager.execute_update(
@@ -602,6 +591,48 @@ class RepeaterManager:
 
         except Exception as e:
             self.logger.error(f"Error updating currently tracked status: {e}")
+
+    def get_tracked_contact_row(self, public_key: str) -> Optional[dict[str, Any]]:
+        """Return a tracked contact row by public key, or None when absent."""
+        try:
+            rows = self.db_manager.execute_query(
+                '''
+                SELECT public_key, name, role, device_type, first_heard, last_heard,
+                       advert_count, is_currently_tracked
+                FROM complete_contact_tracking
+                WHERE public_key = ?
+                LIMIT 1
+                ''',
+                (public_key,),
+            )
+            return rows[0] if rows else None
+        except Exception as e:
+            self.logger.debug("Error looking up tracked contact %s: %s", public_key[:16], e)
+            return None
+
+    def is_contact_on_device(self, public_key: str) -> bool:
+        """Return True when the radio's live contact table already contains public_key."""
+        try:
+            if hasattr(self.bot.meshcore, 'contacts'):
+                for contact_key, contact_data in list(self.bot.meshcore.contacts.items()):
+                    if contact_data.get('public_key', contact_key) == public_key:
+                        return True
+        except Exception as e:
+            self.logger.debug("Error checking live device contacts for %s: %s", public_key[:16], e)
+        return False
+
+    async def refresh_device_contacts(self) -> bool:
+        """Refresh meshcore.contacts from the radio when supported."""
+        try:
+            if not getattr(self.bot, 'meshcore', None) or not hasattr(self.bot.meshcore, 'commands'):
+                return False
+            if not hasattr(self.bot.meshcore.commands, 'get_contacts'):
+                return False
+            await self.bot.meshcore.commands.get_contacts()
+            return True
+        except Exception as e:
+            self.logger.debug("Failed to refresh device contacts: %s", e)
+            return False
 
     async def get_complete_contact_database(self, role_filter: Optional[str] = None, include_historical: bool = True) -> list[dict]:
         """Get complete contact database for path estimation and analysis"""
@@ -2830,48 +2861,67 @@ class RepeaterManager:
         code_str = str(payload.get('code_string', '') or '')
         return 'TABLE_FULL' in code_str.upper()
 
-    async def add_companion_from_contact_data(
+    async def add_contact_from_contact_data(
         self,
         contact_data: dict[str, Any],
         contact_name: str,
         public_key: str,
+        contact_kind: str = "contact",
     ) -> bool:
-        """Add companion using full contact_data (paths). Pre-manages when near limit; retries once on TABLE_FULL."""
+        """Add a contact using full contact_data (paths). Pre-manage when near limit; retry once on TABLE_FULL."""
         try:
             if not self.bot.meshcore or not hasattr(self.bot.meshcore, 'commands'):
-                self.logger.error('No meshcore commands — cannot add companion %s', contact_name)
+                self.logger.error('No meshcore commands — cannot add %s %s', contact_kind, contact_name)
                 return False
 
             status = await self.get_contact_list_status()
             if status and status.get('is_near_limit'):
                 self.logger.warning(
-                    'Contact list near limit (%.1f%%) before add — managing capacity for %s',
+                    'Contact list near limit (%.1f%%) before add — managing capacity for %s %s',
                     status.get('usage_percentage', 0.0),
+                    contact_kind,
                     contact_name,
                 )
                 await self.manage_contact_list(auto_cleanup=True)
 
             result = await self.bot.meshcore.commands.add_contact(contact_data)
             if hasattr(result, 'type') and result.type == EventType.OK:
-                self.logger.info("Companion %s added to device contacts", contact_name)
+                self.logger.info("%s %s added to device contacts", contact_kind.capitalize(), contact_name)
+                await self.refresh_device_contacts()
                 return True
 
             if self._is_meshcore_table_full(result):
                 self.logger.warning(
-                    'TABLE_FULL adding companion %s — running manage_contact_list and retrying once',
+                    'TABLE_FULL adding %s %s — running manage_contact_list and retrying once',
+                    contact_kind,
                     contact_name,
                 )
                 await self.manage_contact_list(auto_cleanup=True)
                 result = await self.bot.meshcore.commands.add_contact(contact_data)
                 if hasattr(result, 'type') and result.type == EventType.OK:
-                    self.logger.info('Companion %s added after retry', contact_name)
+                    self.logger.info('%s %s added after retry', contact_kind.capitalize(), contact_name)
+                    await self.refresh_device_contacts()
                     return True
 
-            self.logger.warning('Failed to add companion %s to device: %s', contact_name, result)
+            self.logger.warning('Failed to add %s %s to device: %s', contact_kind, contact_name, result)
             return False
         except Exception as e:
-            self.logger.error('Error adding companion %s: %s', contact_name, e)
+            self.logger.error('Error adding %s %s: %s', contact_kind, contact_name, e)
             return False
+
+    async def add_companion_from_contact_data(
+        self,
+        contact_data: dict[str, Any],
+        contact_name: str,
+        public_key: str,
+    ) -> bool:
+        """Backward-compatible wrapper for companion add path."""
+        return await self.add_contact_from_contact_data(
+            contact_data,
+            contact_name,
+            public_key,
+            contact_kind="companion",
+        )
 
     async def apply_device_mode_firmware_preferences(self) -> bool:
         """Set companion-radio firmware: manual per-type adds + overwrite oldest non-favourite + chat-only (0x03)."""

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1968,7 +1968,11 @@ def new_contact_env(mock_logger):
     )
     rm.manage_contact_list = AsyncMock(return_value={"success": True})
     rm.add_companion_from_contact_data = AsyncMock(return_value=True)
+    rm.add_contact_from_contact_data = AsyncMock(return_value=True)
+    rm.refresh_device_contacts = AsyncMock(return_value=True)
     rm.log_purging_action = Mock()
+    rm.get_tracked_contact_row = Mock(return_value=None)
+    rm.is_contact_on_device = Mock(return_value=False)
     rm.db_manager = Mock()
     rm.db_manager.execute_update = Mock()
     rm._is_repeater_device = Mock(return_value=False)
@@ -1992,24 +1996,36 @@ class TestHandleNewContactAutoManage:
         rm.track_contact_advertisement.assert_awaited_once()
         mesh.commands.add_contact.assert_not_called()
         rm.add_companion_from_contact_data.assert_not_called()
+        rm.add_contact_from_contact_data.assert_not_called()
         rm.log_purging_action.assert_called_once()
 
     async def test_device_mode_no_bot_add_contact(self, new_contact_env):
         bot, handler, rm, mesh = new_contact_env
         bot.config.set("Bot", "auto_manage_contacts", "device")
+        rm.is_contact_on_device.return_value = True
         ev = _NewContactEvent(_companion_contact_payload())
         await handler.handle_new_contact(ev, None)
         rm.track_contact_advertisement.assert_awaited_once()
         mesh.commands.add_contact.assert_not_called()
         rm.add_companion_from_contact_data.assert_not_called()
+        rm.add_contact_from_contact_data.assert_not_called()
         rm.get_contact_list_status.assert_awaited()
 
-    async def test_bot_mode_uses_add_companion_from_contact_data(self, new_contact_env):
+    async def test_device_mode_adds_contact_when_missing_from_radio_db(self, new_contact_env):
+        bot, handler, rm, mesh = new_contact_env
+        bot.config.set("Bot", "auto_manage_contacts", "device")
+        ev = _NewContactEvent(_companion_contact_payload())
+        await handler.handle_new_contact(ev, None)
+        rm.add_contact_from_contact_data.assert_awaited_once()
+        rm.add_companion_from_contact_data.assert_not_called()
+
+    async def test_bot_mode_uses_add_contact_from_contact_data(self, new_contact_env):
         bot, handler, rm, mesh = new_contact_env
         bot.config.set("Bot", "auto_manage_contacts", "bot")
         ev = _NewContactEvent(_companion_contact_payload())
         await handler.handle_new_contact(ev, None)
-        rm.add_companion_from_contact_data.assert_awaited_once()
+        rm.add_contact_from_contact_data.assert_awaited_once()
+        rm.add_companion_from_contact_data.assert_not_called()
         mesh.commands.add_contact.assert_not_called()
 
     async def test_bot_mode_skips_add_when_duplicate_packet_hash(self, new_contact_env):
@@ -2023,7 +2039,7 @@ class TestHandleNewContactAutoManage:
         ev = _NewContactEvent(_companion_contact_payload())
         await handler.handle_new_contact(ev, None)
         rm.track_contact_advertisement.assert_awaited_once()
-        rm.add_companion_from_contact_data.assert_not_called()
+        rm.add_contact_from_contact_data.assert_not_called()
         rm.get_contact_list_status.assert_not_awaited()
 
     async def test_bot_mode_two_events_first_unique_then_duplicate_adds_once(self, new_contact_env):
@@ -2041,4 +2057,87 @@ class TestHandleNewContactAutoManage:
         await handler.handle_new_contact(ev, None)
         await handler.handle_new_contact(ev, None)
         assert rm.track_contact_advertisement.await_count == 2
-        rm.add_companion_from_contact_data.assert_awaited_once()
+        rm.add_contact_from_contact_data.assert_awaited_once()
+
+    async def test_existing_companion_skips_new_contact_audit_log(self, new_contact_env):
+        bot, handler, rm, mesh = new_contact_env
+        bot.config.set("Bot", "auto_manage_contacts", "false")
+        rm.get_tracked_contact_row.return_value = {
+            "public_key": _companion_contact_payload()["public_key"],
+            "name": "Alice",
+            "role": "companion",
+        }
+
+        ev = _NewContactEvent(_companion_contact_payload())
+        await handler.handle_new_contact(ev, None)
+
+        rm.log_purging_action.assert_not_called()
+
+    async def test_existing_companion_logs_known_not_new(self, new_contact_env):
+        bot, handler, rm, mesh = new_contact_env
+        bot.config.set("Bot", "auto_manage_contacts", "false")
+        rm.get_tracked_contact_row.return_value = {
+            "public_key": _companion_contact_payload()["public_key"],
+            "name": "Alice",
+            "role": "companion",
+        }
+
+        ev = _NewContactEvent(_companion_contact_payload())
+        await handler.handle_new_contact(ev, None)
+
+        log_messages = [str(call.args[0]) for call in bot.logger.info.call_args_list if call.args]
+        assert any("Known companion advert" in msg for msg in log_messages)
+        assert not any("New companion discovered" in msg for msg in log_messages)
+
+
+@pytest.mark.asyncio
+async def test_existing_repeater_logs_known_not_new(mock_logger):
+    bot = Mock()
+    bot.logger = mock_logger
+    bot.config = configparser.ConfigParser()
+    bot.config.add_section("Bot")
+    bot.config.set("Bot", "enabled", "true")
+    bot.config.set("Bot", "rf_data_timeout", "15.0")
+    bot.config.set("Bot", "message_correlation_timeout", "10.0")
+    bot.config.set("Bot", "enable_enhanced_correlation", "true")
+    bot.connection_time = None
+    bot.prefix_hex_chars = 8
+    bot.command_manager = Mock()
+    bot.command_manager.monitor_channels = ["general"]
+    bot.command_manager.is_user_banned = Mock(return_value=False)
+    bot.command_manager.commands = {}
+
+    handler = MessageHandler(bot)
+    bot.message_handler = handler
+
+    rm = Mock()
+    from modules.repeater_manager import TrackAdvertResult
+
+    rm._is_repeater_device = Mock(return_value=True)
+    rm.get_tracked_contact_row = Mock(
+        return_value={"public_key": "cd" * 32, "name": "Roof", "role": "repeater"}
+    )
+    rm.is_contact_on_device = Mock(return_value=False)
+    rm.refresh_device_contacts = AsyncMock(return_value=True)
+    rm.track_contact_advertisement = AsyncMock(
+        return_value=TrackAdvertResult(ok=True, duplicate_packet=False)
+    )
+    rm.add_contact_from_contact_data = AsyncMock(return_value=True)
+    rm.check_and_auto_purge = AsyncMock()
+    bot.repeater_manager = rm
+    bot.web_viewer_integration = None
+
+    payload = {
+        "public_key": "cd" * 32,
+        "adv_name": "Roof",
+        "name": "Roof",
+        "type": 2,
+        "flags": 0,
+    }
+    ev = _NewContactEvent(payload)
+    await handler.handle_new_contact(ev, None)
+
+    log_messages = [str(call.args[0]) for call in bot.logger.info.call_args_list if call.args]
+    assert any("Known repeater advert" in msg for msg in log_messages)
+    assert not any("New repeater discovered" in msg for msg in log_messages)
+    rm.add_contact_from_contact_data.assert_awaited_once()


### PR DESCRIPTION
This PR fixes how the bot handles `NEW_CONTACT` events.  I have not fully tested it, Just thought id PR some ideas on this topic as the bot logging for adverts is annoying if its new or not, its always saying its new.

Right now the bot can log a repeater as newly discovered and “database only” even when the firmware has already added that node to the radio’s contact list. The issue is that the handler was making its decision too early, without checking the live contact state on the radio first.

This change makes the bot check the radio contact list before deciding whether a node is actually new.

## Changes

- Refresh the radio contact list before classifying a `NEW_CONTACT`
- Check both the live radio contacts and the bot tracking database
- Treat the radio contact list as the source of truth for whether the node is already on-device
- If the node is already on the radio:
  - do not log it as new
  - update tracking data in the bot database and continue
- If the node is missing from the radio:
  - treat it as new/missing
  - store it in the bot database
  - attempt to add it to the radio contact list
- Reuse the full `NEW_CONTACT` payload when adding contacts so path data is preserved
- Skip the `new_contact_discovered` audit entry for nodes that are already known

## Why

In `auto_manage_contacts=device` mode, the firmware should usually be handling contact creation already. The bot should reflect the actual state of the radio instead of assuming every `NEW_CONTACT` event means a brand new node.

This makes the logs more accurate and avoids the repeated “new repeater discovered” / “tracking in database only” messages for nodes that are already present.

## Expected behavior after this change

When a node advert is heard and a `NEW_CONTACT` event follows:

- If the node is already in the radio contact list, the bot treats it as known and just updates its own tracking data
- If the node is not in the radio contact list, the bot treats it as new and attempts to sync it into both places

## Files

- `modules/message_handler.py`
- `modules/repeater_manager.py`
- `tests/test_message_handler.py`

## Validation

- Updated tests for known vs new contact handling
- Verified edited files compile cleanly with `python -m py_compile`

## Note

There is still a possible timing edge case if the firmware has emitted `NEW_CONTACT` but has not populated the contact table yet by the time the bot checks it. In that case the bot may still treat the node as missing and try to repair it. That fallback is intentional.