### PR TITLE
feat(weather): flexible forecast scheduling (multiple times, intervals)

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -1684,9 +1684,11 @@ enabled = false
 # flood_scope = #west
 
 # Daily weather forecast time
-# Format: HH:MM (24-hour format, e.g., "6:00" for 6 AM)
+# Single time: HH:MM (24-hour format, e.g., "6:00" for 6 AM)
+# Multiple times: comma-separated (e.g., "6:00, 12:00, 18:00")
+# Interval: "every hour", "every 2 hours", "every 30 minutes", or "@hourly"
 # Or use "sunrise" or "sunset" for dynamic times based on your location
-# Bot will send daily weather forecast at this time
+# Bot will send weather forecast at the configured schedule
 weather_alarm = 6:00
 
 # NOTE: Temperature, wind speed, and precipitation units are inherited from [Weather] section

--- a/docs/weather-service.md
+++ b/docs/weather-service.md
@@ -18,6 +18,8 @@ my_position_lon = -122.3321
 
 # Daily forecast time
 weather_alarm = 6:00              # Or "sunrise" / "sunset"
+# weather_alarm = 6:00, 12:00, 18:00   # Multiple times per day
+# weather_alarm = every hour             # Or every 2 hours, every 30 minutes, @hourly
 
 # Channels
 weather_channel = #weather
@@ -37,7 +39,7 @@ alerts_channel = #weather
 enabled = true
 my_position_lat = 47.6062         # Your latitude (required)
 my_position_lon = -122.3321       # Your longitude (required)
-weather_alarm = 6:00              # Time for daily forecast (HH:MM or sunrise/sunset)
+weather_alarm = 6:00              # Time(s) for forecast (see Scheduling Options below)
 weather_channel = #weather        # Channel for forecasts
 alerts_channel = #weather         # Channel for weather alerts
 ```
@@ -83,6 +85,8 @@ Sends forecast to `weather_channel` at configured time:
 
 **Scheduling Options:**
 - Fixed time: `weather_alarm = 6:00` (24-hour format)
+- Multiple times: `weather_alarm = 6:00, 12:00, 18:00`
+- Interval: `weather_alarm = every hour` (also `every 2 hours`, `every 30 minutes`, `@hourly`)
 - Sunrise: `weather_alarm = sunrise`
 - Sunset: `weather_alarm = sunset`
 

--- a/modules/service_plugins/weather_alarm_schedule.py
+++ b/modules/service_plugins/weather_alarm_schedule.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Parse ``[Weather_Service] weather_alarm`` schedule expressions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from apscheduler.triggers.cron import CronTrigger
+
+
+@dataclass(frozen=True)
+class WeatherAlarmSchedule:
+    """Parsed weather forecast schedule."""
+
+    mode: str
+    """``fixed``, ``interval``, or ``sun_event``."""
+
+    fixed_times: list[tuple[int, int]] = field(default_factory=list)
+    interval_hours: int | None = None
+    interval_minutes: int | None = None
+    sun_event: str | None = None
+    display: str = ""
+
+
+def parse_clock_time(time_str: str) -> tuple[int, int]:
+    """Parse ``HH:MM``, ``H:MM``, or legacy ``HHMM`` into hour and minute.
+
+    Raises:
+        ValueError: If the time string is invalid.
+    """
+    raw = (time_str or "").strip()
+    if not raw:
+        raise ValueError("empty time")
+
+    if ":" in raw:
+        parts = raw.split(":", 1)
+        hour = int(parts[0])
+        minute = int(parts[1])
+    elif len(raw) == 4 and raw.isdigit():
+        hour = int(raw[:2])
+        minute = int(raw[2:])
+    else:
+        raise ValueError(f"invalid time format: {time_str!r}")
+
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"invalid time value: {time_str!r}")
+
+    return hour, minute
+
+
+def parse_weather_alarm_schedule(raw: str) -> WeatherAlarmSchedule:
+    """Parse ``weather_alarm`` config value.
+
+    Supported forms:
+    - Fixed clock time: ``6:00``, ``0600``
+    - Multiple times: ``6:00, 12:00, 18:00``
+    - Interval: ``every hour``, ``every 2 hours``, ``every 30 minutes``, ``@hourly``
+    - Sun events: ``sunrise``, ``sunset``
+    """
+    value = (raw or "6:00").strip()
+    lowered = value.lower()
+
+    if lowered in ("sunrise", "sunset"):
+        return WeatherAlarmSchedule(mode="sun_event", sun_event=lowered, display=lowered)
+
+    if lowered == "@hourly":
+        return WeatherAlarmSchedule(
+            mode="interval",
+            interval_hours=1,
+            display="every hour",
+        )
+
+    hour_match = re.fullmatch(r"every\s+(?:(\d+)\s+)?hours?", lowered)
+    if hour_match:
+        hours = int(hour_match.group(1) or "1")
+        if not (1 <= hours <= 24):
+            raise ValueError(f"invalid hourly interval: {hours}")
+        label = "every hour" if hours == 1 else f"every {hours} hours"
+        return WeatherAlarmSchedule(
+            mode="interval",
+            interval_hours=hours,
+            display=label,
+        )
+
+    minute_match = re.fullmatch(r"every\s+(\d+)\s+minutes?", lowered)
+    if minute_match:
+        minutes = int(minute_match.group(1))
+        if not (1 <= minutes <= 59):
+            raise ValueError(f"invalid minute interval: {minutes}")
+        label = "every minute" if minutes == 1 else f"every {minutes} minutes"
+        return WeatherAlarmSchedule(
+            mode="interval",
+            interval_minutes=minutes,
+            display=label,
+        )
+
+    if "," in value:
+        parts = [part.strip() for part in value.split(",") if part.strip()]
+        if not parts:
+            raise ValueError("empty schedule list")
+        fixed_times = [parse_clock_time(part) for part in parts]
+        display = ", ".join(f"{hour:02d}:{minute:02d}" for hour, minute in fixed_times)
+        return WeatherAlarmSchedule(mode="fixed", fixed_times=fixed_times, display=display)
+
+    hour, minute = parse_clock_time(value)
+    return WeatherAlarmSchedule(
+        mode="fixed",
+        fixed_times=[(hour, minute)],
+        display=f"{hour:02d}:{minute:02d}",
+    )
+
+
+def build_forecast_cron_triggers(
+    schedule: WeatherAlarmSchedule,
+    timezone,
+) -> list[tuple[str, CronTrigger, str]]:
+    """Build APScheduler cron triggers for a parsed schedule.
+
+    Returns:
+        List of ``(job_id, trigger, label)`` tuples.
+    """
+    if schedule.mode == "fixed":
+        triggers: list[tuple[str, CronTrigger, str]] = []
+        for hour, minute in schedule.fixed_times:
+            label = f"{hour:02d}:{minute:02d}"
+            triggers.append(
+                (
+                    f"weather_forecast_{hour:02d}{minute:02d}",
+                    CronTrigger(hour=hour, minute=minute, timezone=timezone),
+                    label,
+                )
+            )
+        return triggers
+
+    if schedule.mode == "interval":
+        if schedule.interval_hours is not None:
+            hours = schedule.interval_hours
+            if hours == 1:
+                trigger = CronTrigger(minute=0, timezone=timezone)
+            elif hours == 24:
+                trigger = CronTrigger(hour=0, minute=0, timezone=timezone)
+            else:
+                trigger = CronTrigger(hour=f"*/{hours}", minute=0, timezone=timezone)
+            return [("weather_forecast_interval", trigger, schedule.display)]
+
+        if schedule.interval_minutes is not None:
+            minutes = schedule.interval_minutes
+            trigger = CronTrigger(minute=f"*/{minutes}", timezone=timezone)
+            return [("weather_forecast_interval", trigger, schedule.display)]
+
+    raise ValueError(f"unsupported schedule mode: {schedule.mode}")

--- a/modules/service_plugins/weather_alarm_schedule.py
+++ b/modules/service_plugins/weather_alarm_schedule.py
@@ -7,6 +7,8 @@ import re
 from dataclasses import dataclass, field
 
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+from apscheduler.triggers.base import BaseTrigger
 
 
 @dataclass(frozen=True)
@@ -114,14 +116,18 @@ def parse_weather_alarm_schedule(raw: str) -> WeatherAlarmSchedule:
 def build_forecast_cron_triggers(
     schedule: WeatherAlarmSchedule,
     timezone,
-) -> list[tuple[str, CronTrigger, str]]:
-    """Build APScheduler cron triggers for a parsed schedule.
+) -> list[tuple[str, BaseTrigger, str]]:
+    """Build APScheduler triggers for a parsed schedule.
+
+    Fixed times use ``CronTrigger``; intervals use ``IntervalTrigger`` so that
+    the period is counted from the moment the scheduler starts rather than
+    being pinned to clock boundaries (e.g. 00:00, 02:00, 04:00 …).
 
     Returns:
         List of ``(job_id, trigger, label)`` tuples.
     """
     if schedule.mode == "fixed":
-        triggers: list[tuple[str, CronTrigger, str]] = []
+        triggers: list[tuple[str, BaseTrigger, str]] = []
         for hour, minute in schedule.fixed_times:
             label = f"{hour:02d}:{minute:02d}"
             triggers.append(
@@ -135,18 +141,11 @@ def build_forecast_cron_triggers(
 
     if schedule.mode == "interval":
         if schedule.interval_hours is not None:
-            hours = schedule.interval_hours
-            if hours == 1:
-                trigger = CronTrigger(minute=0, timezone=timezone)
-            elif hours == 24:
-                trigger = CronTrigger(hour=0, minute=0, timezone=timezone)
-            else:
-                trigger = CronTrigger(hour=f"*/{hours}", minute=0, timezone=timezone)
+            trigger = IntervalTrigger(hours=schedule.interval_hours, timezone=timezone)
             return [("weather_forecast_interval", trigger, schedule.display)]
 
         if schedule.interval_minutes is not None:
-            minutes = schedule.interval_minutes
-            trigger = CronTrigger(minute=f"*/{minutes}", timezone=timezone)
+            trigger = IntervalTrigger(minutes=schedule.interval_minutes, timezone=timezone)
             return [("weather_forecast_interval", trigger, schedule.display)]
 
     raise ValueError(f"unsupported schedule mode: {schedule.mode}")

--- a/modules/service_plugins/weather_service.py
+++ b/modules/service_plugins/weather_service.py
@@ -16,7 +16,6 @@ from typing import Any, Optional
 import ephem
 import requests
 from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -33,6 +32,11 @@ import contextlib
 from ..url_shortener import shorten_url
 from ..utils import format_temperature_high_low, get_config_timezone
 from .base_service import BaseServicePlugin
+from .weather_alarm_schedule import (
+    WeatherAlarmSchedule,
+    build_forecast_cron_triggers,
+    parse_weather_alarm_schedule,
+)
 
 
 class WeatherService(BaseServicePlugin):
@@ -54,7 +58,8 @@ class WeatherService(BaseServicePlugin):
         super().__init__(bot)
 
         # Configuration
-        self.weather_alarm_time = self.bot.config.get('Weather_Service', 'weather_alarm', fallback='6:00')
+        self.weather_alarm_raw = self.bot.config.get('Weather_Service', 'weather_alarm', fallback='6:00')
+        self.weather_schedule = self._load_weather_schedule(self.weather_alarm_raw)
         self.my_position_lat = self.bot.config.getfloat('Weather_Service', 'my_position_lat', fallback=None)
         self.my_position_lon = self.bot.config.getfloat('Weather_Service', 'my_position_lon', fallback=None)
         self.weather_channel = self.bot.config.get('Weather_Service', 'weather_channel', fallback='general')
@@ -112,12 +117,29 @@ class WeatherService(BaseServicePlugin):
         self.mqtt_task: Optional[asyncio.Task] = None
 
         # Check if using sunrise/sunset
-        self.use_sunrise_sunset = self.weather_alarm_time.lower() in ['sunrise', 'sunset']
+        self.use_sunrise_sunset = self.weather_schedule.mode == 'sun_event'
 
         # Cache for location name (to avoid repeated reverse geocoding)
         self._cached_location_name: Optional[str] = None
 
-        self.logger.info(f"Weather service initialized: position=({self.my_position_lat}, {self.my_position_lon}), alarm={self.weather_alarm_time}")
+        self.logger.info(
+            "Weather service initialized: position=(%s, %s), alarm=%s",
+            self.my_position_lat,
+            self.my_position_lon,
+            self.weather_schedule.display,
+        )
+
+    def _load_weather_schedule(self, raw: str) -> WeatherAlarmSchedule:
+        """Load and validate weather forecast schedule from config."""
+        try:
+            return parse_weather_alarm_schedule(raw)
+        except ValueError as exc:
+            self.logger.warning(
+                "Invalid weather_alarm %r (%s), falling back to 6:00",
+                raw,
+                exc,
+            )
+            return parse_weather_alarm_schedule('6:00')
 
     def _load_weather_model(self) -> Optional[str]:
         """Load and normalize Open-Meteo model selection from config.
@@ -210,8 +232,8 @@ class WeatherService(BaseServicePlugin):
             # For sunrise/sunset, use a background task that reschedules daily
             self._forecast_task = asyncio.create_task(self._sunrise_sunset_forecast_loop())
         else:
-            # For fixed times, use APScheduler (BackgroundScheduler + daily cron)
-            self._setup_daily_forecast()
+            # For fixed times and intervals, use APScheduler cron jobs
+            self._setup_forecast_schedule()
 
         # Start background tasks
         self._alerts_task = asyncio.create_task(self._poll_weather_alerts_loop())
@@ -273,17 +295,9 @@ class WeatherService(BaseServicePlugin):
 
         self.logger.info("Weather service stopped")
 
-    def _setup_daily_forecast(self) -> None:
-        """Setup daily weather forecast schedule for fixed times (APScheduler cron, bot timezone)."""
+    def _setup_forecast_schedule(self) -> None:
+        """Setup weather forecast schedule (fixed times or intervals, bot timezone)."""
         try:
-            # Parse time (format: "HH:MM" or "H:MM")
-            if ':' in self.weather_alarm_time:
-                hour, minute = map(int, self.weather_alarm_time.split(':'))
-            else:
-                # Assume format "HHMM"
-                hour = int(self.weather_alarm_time[:2])
-                minute = int(self.weather_alarm_time[2:])
-
             if self._forecast_scheduler is not None:
                 try:
                     self._forecast_scheduler.shutdown(wait=False)
@@ -292,29 +306,31 @@ class WeatherService(BaseServicePlugin):
                 self._forecast_scheduler = None
 
             tz, _ = get_config_timezone(self.bot.config, self.logger)
+            triggers = build_forecast_cron_triggers(self.weather_schedule, tz)
             self._forecast_scheduler = BackgroundScheduler(timezone=tz)
-            self._forecast_scheduler.add_job(
-                self._send_daily_forecast,
-                CronTrigger(hour=hour, minute=minute),
-                id="weather_daily_forecast",
-                replace_existing=True,
-            )
+            for job_id, trigger, label in triggers:
+                self._forecast_scheduler.add_job(
+                    self._send_daily_forecast,
+                    trigger,
+                    id=job_id,
+                    replace_existing=True,
+                )
             self._forecast_scheduler.start()
+            labels = ", ".join(label for _, _, label in triggers)
             self.logger.info(
-                "Scheduled daily weather forecast at %02d:%02d (%s)",
-                hour,
-                minute,
+                "Scheduled weather forecast (%s) in %s",
+                labels,
                 getattr(tz, "zone", tz),
             )
         except Exception as e:
-            self.logger.error(f"Error setting up daily forecast schedule: {e}")
+            self.logger.error(f"Error setting up forecast schedule: {e}")
 
     async def _sunrise_sunset_forecast_loop(self) -> None:
         """Background task for sunrise/sunset-based forecasts.
 
         Calculates daily sunrise/sunset times and schedules the forecast accordingly.
         """
-        event_type = self.weather_alarm_time.lower()
+        event_type = self.weather_schedule.sun_event or 'sunrise'
         self.logger.info(f"Starting {event_type}-based forecast loop")
 
         while self._running:

--- a/tests/unit/test_weather_alarm_schedule.py
+++ b/tests/unit/test_weather_alarm_schedule.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Unit tests for weather_alarm schedule parsing."""
+
+import pytest
+
+from modules.service_plugins.weather_alarm_schedule import (
+    build_forecast_cron_triggers,
+    parse_clock_time,
+    parse_weather_alarm_schedule,
+)
+
+
+def test_parse_clock_time_hhmm_colon():
+    assert parse_clock_time("6:00") == (6, 0)
+    assert parse_clock_time("06:30") == (6, 30)
+
+
+def test_parse_clock_time_legacy_hhmm():
+    assert parse_clock_time("0630") == (6, 30)
+
+
+def test_parse_weather_alarm_single_fixed_time():
+    schedule = parse_weather_alarm_schedule("6:00")
+    assert schedule.mode == "fixed"
+    assert schedule.fixed_times == [(6, 0)]
+    assert schedule.display == "06:00"
+
+
+def test_parse_weather_alarm_multiple_fixed_times():
+    schedule = parse_weather_alarm_schedule("6:00, 12:00, 18:00")
+    assert schedule.mode == "fixed"
+    assert schedule.fixed_times == [(6, 0), (12, 0), (18, 0)]
+    assert schedule.display == "06:00, 12:00, 18:00"
+
+
+def test_parse_weather_alarm_every_hour_variants():
+    assert parse_weather_alarm_schedule("every hour").interval_hours == 1
+    assert parse_weather_alarm_schedule("every 1 hour").interval_hours == 1
+    assert parse_weather_alarm_schedule("every 2 hours").interval_hours == 2
+    assert parse_weather_alarm_schedule("@hourly").interval_hours == 1
+
+
+def test_parse_weather_alarm_every_minutes():
+    schedule = parse_weather_alarm_schedule("every 30 minutes")
+    assert schedule.mode == "interval"
+    assert schedule.interval_minutes == 30
+
+
+def test_parse_weather_alarm_sun_events():
+    sunrise = parse_weather_alarm_schedule("sunrise")
+    assert sunrise.mode == "sun_event"
+    assert sunrise.sun_event == "sunrise"
+
+    sunset = parse_weather_alarm_schedule("Sunset")
+    assert sunset.mode == "sun_event"
+    assert sunset.sun_event == "sunset"
+
+
+def test_parse_weather_alarm_invalid_time():
+    with pytest.raises(ValueError):
+        parse_clock_time("25:00")
+
+
+def test_build_forecast_cron_triggers_fixed_times():
+    schedule = parse_weather_alarm_schedule("6:00, 18:00")
+    triggers = build_forecast_cron_triggers(schedule, "UTC")
+    assert len(triggers) == 2
+    assert triggers[0][0] == "weather_forecast_0600"
+    assert triggers[1][0] == "weather_forecast_1800"
+
+
+def test_build_forecast_cron_triggers_hourly():
+    schedule = parse_weather_alarm_schedule("every hour")
+    triggers = build_forecast_cron_triggers(schedule, "UTC")
+    assert len(triggers) == 1
+    assert triggers[0][0] == "weather_forecast_interval"

--- a/tests/unit/test_weather_alarm_schedule.py
+++ b/tests/unit/test_weather_alarm_schedule.py
@@ -3,6 +3,9 @@
 
 import pytest
 
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
 from modules.service_plugins.weather_alarm_schedule import (
     build_forecast_cron_triggers,
     parse_clock_time,
@@ -67,6 +70,9 @@ def test_build_forecast_cron_triggers_fixed_times():
     assert len(triggers) == 2
     assert triggers[0][0] == "weather_forecast_0600"
     assert triggers[1][0] == "weather_forecast_1800"
+    # Fixed times must use CronTrigger
+    assert isinstance(triggers[0][1], CronTrigger)
+    assert isinstance(triggers[1][1], CronTrigger)
 
 
 def test_build_forecast_cron_triggers_hourly():
@@ -74,3 +80,21 @@ def test_build_forecast_cron_triggers_hourly():
     triggers = build_forecast_cron_triggers(schedule, "UTC")
     assert len(triggers) == 1
     assert triggers[0][0] == "weather_forecast_interval"
+    # Intervals must use IntervalTrigger, not CronTrigger
+    assert isinstance(triggers[0][1], IntervalTrigger)
+
+
+def test_build_forecast_cron_triggers_every_n_hours():
+    schedule = parse_weather_alarm_schedule("every 2 hours")
+    triggers = build_forecast_cron_triggers(schedule, "UTC")
+    assert len(triggers) == 1
+    assert triggers[0][0] == "weather_forecast_interval"
+    assert isinstance(triggers[0][1], IntervalTrigger)
+
+
+def test_build_forecast_cron_triggers_every_minutes():
+    schedule = parse_weather_alarm_schedule("every 30 minutes")
+    triggers = build_forecast_cron_triggers(schedule, "UTC")
+    assert len(triggers) == 1
+    assert triggers[0][0] == "weather_forecast_interval"
+    assert isinstance(triggers[0][1], IntervalTrigger)


### PR DESCRIPTION
Replaces the single fixed-time `weather_alarm` with a flexible schedule parser supporting multiple formats:

- **Multiple fixed times:** `weather_alarm = 6:00, 12:00, 18:00`
- **Intervals:** `every 2 hours`, `every 30 minutes`, `@hourly`
- **Existing formats unchanged:** single time (`6:00`, `0600`), `sunrise`, `sunset`

**Implementation:**
- Extracted schedule parsing into a dedicated `weather_alarm_schedule.py` module (`WeatherAlarmSchedule` dataclass + parser)
- Interval schedules now use APScheduler's `IntervalTrigger` instead of `CronTrigger`, so periods are counted from bot start rather than pinned to clock boundaries
- `WeatherService` registers one APScheduler job per configured time for fixed mode, or a single interval job
- Invalid config values fall back to `6:00` with a warning log

**Tests:** 12 unit tests covering all schedule modes and trigger types.