### PR TITLE
Z-suffixed timestamps for mqtt observers

### DIFF
--- a/modules/service_plugins/packet_capture_service.py
+++ b/modules/service_plugins/packet_capture_service.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 # Import meshcore
@@ -685,7 +685,7 @@ class PacketCaptureService(BaseServicePlugin):
         Returns:
             dict[str, Any]: Formatted packet dictionary.
         """
-        current_time = datetime.now()
+        current_time = datetime.now(timezone.utc)
         timestamp = current_time.isoformat()
 
         # Remove 0x prefix if present
@@ -1831,7 +1831,7 @@ class PacketCaptureService(BaseServicePlugin):
 
         status_msg = {
             "status": status,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "origin": device_name,
             "origin_id": device_public_key,
             "model": firmware_info.get("model", "unknown"),


### PR DESCRIPTION
commit resolves this:

⚠️ Naive observer clock — timing is being clamped
This observer is emitting zone-less local-time timestamps and its clock is currently 7.0h behind UTC. 

Per-packet rxTime for this observer is being collapsed to ingest time, which muddies propagation-delay analytics.

Fix: set the observer host clock to UTC, OR have the observer script emit Z-suffixed (datetime.now(timezone.utc).isoformat()) or offset-aware timestamps. 

here: 
https://analyzer.wcmesh.com/#/observers