### PR TITLE
Adds full server-side filtering and sorting controls to the Contacts list, including path encoding support.

### DIFF
--- a/modules/web_viewer/app.py
+++ b/modules/web_viewer/app.py
@@ -2589,6 +2589,11 @@ class BotDataViewer:
                     except (TypeError, ValueError):
                         page_size = 100
                 search = request.args.get('search', '').strip()[:100]
+                path_bytes = request.args.get('path_bytes', '').strip()
+                device_role = request.args.get('device_role', '').strip()
+                hop_filter = request.args.get('hop_filter', '').strip()
+                location_filter = request.args.get('location_filter', '').strip()
+                starred = request.args.get('starred', '').strip()
                 sort = request.args.get('sort', 'last_seen')
                 direction = request.args.get('direction', 'desc').lower()
                 contacts = self._get_tracking_data(
@@ -2596,6 +2601,11 @@ class BotDataViewer:
                     page=page,
                     page_size=page_size,
                     search=search,
+                    path_bytes=path_bytes,
+                    device_role=device_role,
+                    hop_filter=hop_filter,
+                    location_filter=location_filter,
+                    starred=starred,
                     sort=sort,
                     direction=direction,
                 )
@@ -6604,6 +6614,11 @@ class BotDataViewer:
         page: int | None = None,
         page_size: int | None = None,
         search: str = '',
+        path_bytes: str = '',
+        device_role: str = '',
+        hop_filter: str = '',
+        location_filter: str = '',
+        starred: str = '',
         sort: str = 'last_seen',
         direction: str = 'desc',
     ):
@@ -6637,6 +6652,20 @@ class BotDataViewer:
             }
             where_parts = []
             where_params: list[Any] = []
+            # A node can have more than one observed advert path.  Treat its byte class as
+            # the widest path encoding seen for it, with the contact's current out-path as a
+            # fallback for databases that have not retained an observed path yet.  This gives
+            # the list one stable, sortable value instead of placing the same node in several
+            # byte buckets.
+            path_bytes_expression = """COALESCE((
+                SELECT MAX(CASE WHEN op.bytes_per_hop IN (1, 2, 3)
+                                THEN op.bytes_per_hop ELSE 1 END)
+                FROM observed_paths op
+                WHERE op.public_key = c.public_key
+                  AND op.packet_type = 'advert'
+                  AND op.path_hex IS NOT NULL AND op.path_hex != ''
+            ), CASE WHEN c.out_bytes_per_hop IN (1, 2, 3)
+                     THEN c.out_bytes_per_hop ELSE 0 END)"""
             if since in datetime_offsets:
                 where_parts.append(
                     f"c.last_heard >= datetime('now', 'localtime', {datetime_offsets[since]})"
@@ -6659,6 +6688,44 @@ class BotDataViewer:
                     ")"
                 )
                 where_params.extend([f'{escaped}%'] + [f'%{escaped}%'] * 6)
+
+            path_bytes = str(path_bytes or '').strip()
+            if path_bytes in ('1', '2', '3'):
+                where_parts.append(f'{path_bytes_expression} = ?')
+                where_params.append(int(path_bytes))
+            elif path_bytes == 'unknown':
+                where_parts.append(f'{path_bytes_expression} = 0')
+
+            device_role = str(device_role or '').strip().lower()
+            if device_role in ('companion', 'repeater', 'roomserver', 'sensor'):
+                where_parts.append("LOWER(COALESCE(c.role, '')) = ?")
+                where_params.append(device_role)
+            elif device_role == 'other':
+                where_parts.append("LOWER(COALESCE(c.role, '')) NOT IN ('companion', 'repeater', 'roomserver', 'sensor')")
+
+            if hop_filter in ('0', '1', '2', '3'):
+                where_parts.append(
+                    'COALESCE(c.hop_count, 0) = ?' if hop_filter == '0'
+                    else 'COALESCE(c.hop_count, 0) >= ?'
+                )
+                where_params.append(int(hop_filter))
+
+            has_location_expression = (
+                "((c.city IS NOT NULL AND c.city != '') OR "
+                "(c.state IS NOT NULL AND c.state != '') OR "
+                "(c.country IS NOT NULL AND c.country != '') OR "
+                "(c.latitude IS NOT NULL AND c.longitude IS NOT NULL "
+                "AND c.latitude != 0 AND c.longitude != 0))"
+            )
+            if location_filter == 'known':
+                where_parts.append(has_location_expression)
+            elif location_filter == 'unknown':
+                where_parts.append(f'NOT {has_location_expression}')
+
+            if starred == 'yes':
+                where_parts.append('COALESCE(c.is_starred, 0) = 1')
+            elif starred == 'no':
+                where_parts.append('COALESCE(c.is_starred, 0) = 0')
 
             where_clause = (' WHERE ' + ' AND '.join(where_parts)) if where_parts else ''
 
@@ -6725,6 +6792,7 @@ class BotDataViewer:
                 ),
                 'snr': 'COALESCE(c.snr, 0)',
                 'hop_count': 'COALESCE(c.hop_count, 0)',
+                'path_bytes': path_bytes_expression,
                 'first_heard': "COALESCE(c.first_heard, '')",
                 'last_seen': "COALESCE(c.last_heard, '')",
                 'advert_count': 'COALESCE(c.advert_count, 0)',
@@ -6758,6 +6826,7 @@ class BotDataViewer:
                     """ + detail_cols + """
                     c.signal_strength,
                     c.is_starred, c.out_path, c.out_path_len, c.out_bytes_per_hop,
+                    """ + path_bytes_expression + """ AS path_bytes_per_hop,
                     c.last_advert_timestamp as last_message
                 FROM complete_contact_tracking c
                 """ + where_clause + """
@@ -6876,6 +6945,7 @@ class BotDataViewer:
                     'out_path': out_path_val,
                     'out_path_len': row['out_path_len'] if row['out_path_len'] is not None else -1,
                     'out_bytes_per_hop': out_bytes_per_hop_val,
+                    'path_bytes_per_hop': int(row['path_bytes_per_hop'] or 0),
                     'paths_count': paths_count,
                     'path_encoding_badge': path_encoding_badge,
                 }

--- a/modules/web_viewer/app.py
+++ b/modules/web_viewer/app.py
@@ -6656,14 +6656,15 @@ class BotDataViewer:
             # the widest path encoding seen for it, with the contact's current out-path as a
             # fallback for databases that have not retained an observed path yet.  This gives
             # the list one stable, sortable value instead of placing the same node in several
-            # byte buckets.
+            # byte buckets.  Only count rows with a known 1/2/3 encoding so NULL/invalid
+            # observations do not collapse to "1-byte" and block the out-path fallback.
             path_bytes_expression = """COALESCE((
-                SELECT MAX(CASE WHEN op.bytes_per_hop IN (1, 2, 3)
-                                THEN op.bytes_per_hop ELSE 1 END)
+                SELECT MAX(op.bytes_per_hop)
                 FROM observed_paths op
                 WHERE op.public_key = c.public_key
                   AND op.packet_type = 'advert'
                   AND op.path_hex IS NOT NULL AND op.path_hex != ''
+                  AND op.bytes_per_hop IN (1, 2, 3)
             ), CASE WHEN c.out_bytes_per_hop IN (1, 2, 3)
                      THEN c.out_bytes_per_hop ELSE 0 END)"""
             if since in datetime_offsets:

--- a/modules/web_viewer/templates/contacts.html
+++ b/modules/web_viewer/templates/contacts.html
@@ -86,11 +86,13 @@
 
     .contacts-toolbar-filters .form-select-sm,
     .contacts-toolbar-filters .input-group-sm,
-    .contacts-toolbar-filters #contacts-timespan {
+    .contacts-toolbar-filters #contacts-timespan,
+    .contacts-toolbar-filters #contacts-path-bytes {
         flex-shrink: 0;
     }
 
-    .contacts-toolbar-filters #contacts-timespan {
+    .contacts-toolbar-filters #contacts-timespan,
+    .contacts-toolbar-filters #contacts-path-bytes {
         min-height: 2.375rem;
         padding-top: 0.375rem;
         padding-bottom: 0.375rem;
@@ -346,6 +348,51 @@
                             <option value="90d">Last 90 days</option>
                             <option value="all">All time</option>
                         </select>
+                        <div class="dropdown flex-shrink-0">
+                            <button type="button" class="btn btn-outline-secondary" id="contacts-filters-trigger"
+                                    data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false"
+                                    title="Filter contacts">
+                                <i class="fas fa-filter" aria-hidden="true"></i> Filters
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-end p-3" style="min-width: 15rem;">
+                                <div class="mb-2">
+                                    <label class="form-label small mb-1" for="contacts-device-role">Device role</label>
+                                    <select class="form-select form-select-sm contacts-list-filter" id="contacts-device-role">
+                                        <option value="">Any role</option><option value="companion">Companion</option>
+                                        <option value="repeater">Repeater</option><option value="roomserver">Room server</option>
+                                        <option value="sensor">Sensor</option><option value="other">Other / unknown</option>
+                                    </select>
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label small mb-1" for="contacts-path-bytes">Path bytes per hop</label>
+                                    <select class="form-select form-select-sm contacts-list-filter" id="contacts-path-bytes" title="Uses the widest path encoding observed for each contact">
+                                        <option value="">Any bytes/hop</option><option value="1">1 byte/hop</option>
+                                        <option value="2">2 bytes/hop</option><option value="3">3 bytes/hop</option>
+                                        <option value="unknown">Unknown bytes/hop</option>
+                                    </select>
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label small mb-1" for="contacts-hop-filter">Hops</label>
+                                    <select class="form-select form-select-sm contacts-list-filter" id="contacts-hop-filter">
+                                        <option value="">Any hop count</option><option value="0">Direct only</option>
+                                        <option value="1">1+ hops</option><option value="2">2+ hops</option><option value="3">3+ hops</option>
+                                    </select>
+                                </div>
+                                <div class="mb-2">
+                                    <label class="form-label small mb-1" for="contacts-location-filter">Location</label>
+                                    <select class="form-select form-select-sm contacts-list-filter" id="contacts-location-filter">
+                                        <option value="">Any location</option><option value="known">Location known</option><option value="unknown">Location unknown</option>
+                                    </select>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label small mb-1" for="contacts-starred-filter">Starred</label>
+                                    <select class="form-select form-select-sm contacts-list-filter" id="contacts-starred-filter">
+                                        <option value="">Any star state</option><option value="yes">Starred</option><option value="no">Not starred</option>
+                                    </select>
+                                </div>
+                                <button type="button" class="btn btn-sm btn-outline-secondary w-100" id="contacts-clear-filters">Clear filters</button>
+                            </div>
+                        </div>
                         <div class="dropdown d-md-none flex-shrink-0">
                             <button type="button" class="btn btn-sm btn-outline-secondary contacts-overflow-btn" id="contacts-timespan-mobile-trigger"
                                     data-bs-toggle="dropdown" aria-expanded="false"
@@ -430,6 +477,8 @@
                             <option value="snr|desc">SNR (high first)</option>
                             <option value="hop_count|asc">Hops (low first)</option>
                             <option value="hop_count|desc">Hops (high first)</option>
+                            <option value="path_bytes|asc">Bytes/hop (low first)</option>
+                            <option value="path_bytes|desc">Bytes/hop (high first)</option>
                             <option value="first_heard|asc">First heard (oldest first)</option>
                             <option value="first_heard|desc">First heard (newest first)</option>
                             <option value="last_seen|asc">Last heard (oldest first)</option>
@@ -472,6 +521,9 @@
                                     </button>
                                 </span>
                             </th>
+                            <th class="sortable" data-sort="path_bytes">
+                                Bytes/hop <i class="fas fa-sort"></i>
+                            </th>
                             <th class="sortable" data-sort="first_heard">
                                 First Heard <i class="fas fa-sort"></i>
                             </th>
@@ -486,7 +538,7 @@
                     </thead>
                         <tbody id="contacts-table-body">
                             <tr>
-                                <td colspan="11" class="text-center">
+                                <td colspan="12" class="text-center">
                                     <div class="loading">Loading contacts data...</div>
                                 </td>
                             </tr>
@@ -581,6 +633,7 @@ class ModernContactsManager {
         }
         this.syncContactsTimespanMobileUI();
         this.setupEventHandlers();
+        this.updateFiltersButton();
         const toolbarWrap = document.querySelector('.contacts-toolbar-filters-wrap');
         if (toolbarWrap) this.initContactsDropdowns(toolbarWrap);
         if (this.mobileLayout.addEventListener) {
@@ -603,6 +656,11 @@ class ModernContactsManager {
                 page: String(this.currentPage),
                 page_size: String(this.pageSize),
                 search: this.searchTerm,
+                path_bytes: document.getElementById('contacts-path-bytes').value,
+                device_role: document.getElementById('contacts-device-role').value,
+                hop_filter: document.getElementById('contacts-hop-filter').value,
+                location_filter: document.getElementById('contacts-location-filter').value,
+                starred: document.getElementById('contacts-starred-filter').value,
                 sort: this.sortColumn,
                 direction: this.sortDirection,
             });
@@ -689,6 +747,18 @@ class ModernContactsManager {
             const since = document.getElementById('contacts-timespan').value;
             localStorage.setItem('contactsTimespan', since);
             this.syncContactsTimespanMobileUI();
+            this.loadContactsData({ resetPage: true, clearSelection: true });
+        });
+
+        document.querySelectorAll('.contacts-list-filter').forEach(filter => {
+            filter.addEventListener('change', () => {
+                this.updateFiltersButton();
+                this.loadContactsData({ resetPage: true, clearSelection: true });
+            });
+        });
+        document.getElementById('contacts-clear-filters').addEventListener('click', () => {
+            document.querySelectorAll('.contacts-list-filter').forEach(filter => { filter.value = ''; });
+            this.updateFiltersButton();
             this.loadContactsData({ resetPage: true, clearSelection: true });
         });
 
@@ -881,6 +951,7 @@ class ModernContactsManager {
                             <div class="d-flex align-items-center flex-wrap gap-2 min-w-0">
                                 <div class="d-flex flex-column align-items-start gap-1 min-w-0">
                                 <div class="d-flex align-items-center min-w-0">${this.formatHops(contact)}</div>
+                                <div class="d-flex align-items-center gap-1"><span class="text-muted small">Bytes/hop:</span>${this.formatPathBytes(contact)}</div>
                                 ${this.formatPathEncodingBadge(contact)}
                                 </div>
                                 <div class="d-flex align-items-center gap-1">
@@ -919,7 +990,7 @@ class ModernContactsManager {
                 'No contacts data available';
             const row = document.createElement('tr');
             const cell = document.createElement('td');
-            cell.colSpan = 11;
+            cell.colSpan = 12;
             cell.className = 'text-center text-muted';
             cell.textContent = message;
             row.appendChild(cell);
@@ -951,6 +1022,7 @@ class ModernContactsManager {
                 <td>${this.formatDistance(contact)}</td>
                 <td>${this.formatSignal(contact)}</td>
                 <td><div class="d-flex flex-column align-items-start gap-1">${this.formatHops(contact)}${this.formatPathEncodingBadge(contact)}</div></td>
+                <td>${this.formatPathBytes(contact)}</td>
                 <td>${this.formatTimestamp(contact.first_heard)}</td>
                 <td>${this.formatTimeAgo(contact.last_seen)}</td>
                 <td><span class="badge bg-success">${Number(contact.advert_count) || 0}</span></td>
@@ -1522,6 +1594,23 @@ class ModernContactsManager {
             return '<span class="badge path-encoding-badge path-encoding-badge-onebyte">1-byte only</span>';
         }
         return '';
+    }
+
+    updateFiltersButton() {
+        const trigger = document.getElementById('contacts-filters-trigger');
+        if (!trigger) return;
+        const active = [...document.querySelectorAll('.contacts-list-filter')]
+            .filter(filter => filter.value !== '').length;
+        trigger.innerHTML = `<i class="fas fa-filter" aria-hidden="true"></i> Filters${active ? ` (${active})` : ''}`;
+        trigger.classList.toggle('btn-primary', active > 0);
+        trigger.classList.toggle('btn-outline-secondary', active === 0);
+    }
+
+    formatPathBytes(contact) {
+        const bytes = Number(contact.path_bytes_per_hop);
+        return [1, 2, 3].includes(bytes)
+            ? `<span class="badge bg-primary">${bytes}</span>`
+            : '<span class="text-muted">—</span>';
     }
     
     setupPathTooltips() {

--- a/tests/js/contacts_manager.test.mjs
+++ b/tests/js/contacts_manager.test.mjs
@@ -125,6 +125,11 @@ function successfulResponse(data) {
 test('loadContactsData sends bounded server-side list parameters', async () => {
     const { context, elements, Manager } = loadManagerClass();
     elements.set('contacts-timespan', fakeElement({ value: '30d' }));
+    elements.set('contacts-path-bytes', fakeElement({ value: '2' }));
+    elements.set('contacts-device-role', fakeElement({ value: 'repeater' }));
+    elements.set('contacts-hop-filter', fakeElement({ value: '2' }));
+    elements.set('contacts-location-filter', fakeElement({ value: 'known' }));
+    elements.set('contacts-starred-filter', fakeElement({ value: 'yes' }));
     const manager = bareManager(Manager);
     manager.currentPage = 3;
     manager.searchTerm = 'alpha';
@@ -161,6 +166,11 @@ test('loadContactsData sends bounded server-side list parameters', async () => {
     assert.equal(url.searchParams.get('page'), '3');
     assert.equal(url.searchParams.get('page_size'), '100');
     assert.equal(url.searchParams.get('search'), 'alpha');
+    assert.equal(url.searchParams.get('path_bytes'), '2');
+    assert.equal(url.searchParams.get('device_role'), 'repeater');
+    assert.equal(url.searchParams.get('hop_filter'), '2');
+    assert.equal(url.searchParams.get('location_filter'), 'known');
+    assert.equal(url.searchParams.get('starred'), 'yes');
     assert.equal(url.searchParams.get('sort'), 'distance');
     assert.equal(url.searchParams.get('direction'), 'asc');
     assert.equal(manager.filteredData.length, 1);
@@ -170,6 +180,11 @@ test('loadContactsData sends bounded server-side list parameters', async () => {
 test('a newer contacts request aborts the stale request', async () => {
     const { context, elements, Manager } = loadManagerClass();
     elements.set('contacts-timespan', fakeElement({ value: '30d' }));
+    elements.set('contacts-path-bytes', fakeElement({ value: '' }));
+    elements.set('contacts-device-role', fakeElement({ value: '' }));
+    elements.set('contacts-hop-filter', fakeElement({ value: '' }));
+    elements.set('contacts-location-filter', fakeElement({ value: '' }));
+    elements.set('contacts-starred-filter', fakeElement({ value: '' }));
     const manager = bareManager(Manager);
     manager.setLoadingState = () => {};
     manager.updateSortIcons = () => {};
@@ -215,6 +230,12 @@ test('search is debounced before reloading the first page', () => {
         'refresh-contacts',
         'search-contacts',
         'contacts-timespan',
+        'contacts-path-bytes',
+        'contacts-device-role',
+        'contacts-hop-filter',
+        'contacts-location-filter',
+        'contacts-starred-filter',
+        'contacts-clear-filters',
         'contacts-timespan-mobile-menu',
         'bulk-delete-contacts',
         'contacts-list-panel',

--- a/tests/test_web_viewer.py
+++ b/tests/test_web_viewer.py
@@ -499,6 +499,58 @@ class TestContactRoutes:
         ).get_json()["tracking_data"]
         assert [row["path_bytes_per_hop"] for row in sorted_rows] == [3, 2, 1]
 
+    def test_api_contacts_path_bytes_ignores_invalid_observed_encodings(self, client, viewer):
+        """NULL/invalid observed_paths.bytes_per_hop must not become 1-byte.
+
+        Those rows should be ignored so the contact falls back to out_bytes_per_hop.
+        """
+        public_key = "d804" * 16
+        _insert_contact(viewer, public_key, "PathBytes Fallback")
+        with closing(sqlite3.connect(viewer.db_path)) as conn:
+            conn.execute(
+                """UPDATE complete_contact_tracking
+                   SET out_bytes_per_hop = 3, last_heard = datetime('now', 'localtime')
+                   WHERE public_key = ?""",
+                (public_key,),
+            )
+            conn.execute(
+                """INSERT INTO observed_paths
+                   (public_key, from_prefix, to_prefix, path_hex, path_length,
+                    bytes_per_hop, packet_type, first_seen, last_seen, observation_count)
+                   VALUES (?, 'abcd', 'ef01', 'abcdef01', 4, NULL, 'advert',
+                           datetime('now', 'localtime'), datetime('now', 'localtime'), 1)""",
+                (public_key,),
+            )
+            conn.commit()
+
+        rows = client.get(
+            "/api/contacts",
+            query_string={
+                "since": "all", "page": 1, "page_size": 10,
+                "search": "PathBytes Fallback", "sort": "path_bytes",
+            },
+        ).get_json()["tracking_data"]
+        assert len(rows) == 1
+        assert rows[0]["path_bytes_per_hop"] == 3
+
+        filtered = client.get(
+            "/api/contacts",
+            query_string={
+                "since": "all", "page": 1, "page_size": 10,
+                "search": "PathBytes Fallback", "path_bytes": "3",
+            },
+        ).get_json()["tracking_data"]
+        assert [row["username"] for row in filtered] == ["PathBytes Fallback"]
+
+        as_one_byte = client.get(
+            "/api/contacts",
+            query_string={
+                "since": "all", "page": 1, "page_size": 10,
+                "search": "PathBytes Fallback", "path_bytes": "1",
+            },
+        ).get_json()["tracking_data"]
+        assert as_one_byte == []
+
     @pytest.mark.parametrize(
         ("sort", "ascending_names"),
         [

--- a/tests/test_web_viewer.py
+++ b/tests/test_web_viewer.py
@@ -444,6 +444,61 @@ class TestContactRoutes:
         assert data["pagination"]["page"] == 1
         assert data["pagination"]["page_size"] == 200
 
+    def test_api_contacts_filters_and_sorts_by_path_bytes(self, client, viewer):
+        rows = [
+            ("d801" * 16, "PathBytes One", 1),
+            ("d802" * 16, "PathBytes Three", 3),
+            ("d803" * 16, "PathBytes Two", 2),
+        ]
+        for public_key, name, _bytes_per_hop in rows:
+            _insert_contact(viewer, public_key, name)
+        with closing(sqlite3.connect(viewer.db_path)) as conn:
+            for public_key, _name, bytes_per_hop in rows:
+                conn.execute(
+                    """UPDATE complete_contact_tracking
+                       SET out_bytes_per_hop = ?, role = ?, hop_count = ?, city = ?, is_starred = ?
+                       WHERE public_key = ?""",
+                    (
+                        bytes_per_hop,
+                        'repeater' if bytes_per_hop == 2 else 'companion',
+                        2 if bytes_per_hop == 2 else 0,
+                        'Test City' if bytes_per_hop == 2 else None,
+                        1 if bytes_per_hop == 2 else 0,
+                        public_key,
+                    ),
+                )
+            conn.commit()
+
+        filtered = client.get(
+            "/api/contacts",
+            query_string={
+                "since": "all", "page": 1, "page_size": 10,
+                "search": "PathBytes", "path_bytes": "2", "sort": "path_bytes",
+                "direction": "asc",
+            },
+        ).get_json()
+        assert [row["username"] for row in filtered["tracking_data"]] == ["PathBytes Two"]
+        assert filtered["tracking_data"][0]["path_bytes_per_hop"] == 2
+
+        combined_filters = client.get(
+            "/api/contacts",
+            query_string={
+                "since": "all", "page": 1, "page_size": 10, "search": "PathBytes",
+                "device_role": "repeater", "hop_filter": "2", "location_filter": "known",
+                "starred": "yes",
+            },
+        ).get_json()
+        assert [row["username"] for row in combined_filters["tracking_data"]] == ["PathBytes Two"]
+
+        sorted_rows = client.get(
+            "/api/contacts",
+            query_string={
+                "since": "all", "page": 1, "page_size": 10,
+                "search": "PathBytes", "sort": "path_bytes", "direction": "desc",
+            },
+        ).get_json()["tracking_data"]
+        assert [row["path_bytes_per_hop"] for row in sorted_rows] == [3, 2, 1]
+
     @pytest.mark.parametrize(
         ("sort", "ascending_names"),
         [


### PR DESCRIPTION
**New Contacts filters:**
A compact Filters menu now supports filtering the entire paginated contact list by:

- Device role: Companion, Repeater, Room Server, Sensor, or other/unknown
- Path bytes per hop: 1-byte, 2-byte, 3-byte, or unknown
- Hop count: direct only, 1+, 2+, or 3+ hops
- Location: known or unknown
- Starred status

The Filters button displays the number of active filters and includes a one-click Clear filters action.

**Bytes per hop:**

- Adds a sortable Bytes/hop table column.
- Adds Bytes/hop options to the mobile sort picker.
- Shows the bytes-per-hop value on mobile contact cards.
- Uses the widest advert-path encoding observed for a contact, falling back to its current outbound-path data when no observed advert path is available. This gives each contact one stable byte category for filtering and sorting.

**Implementation details:**

- Filtering, sorting, pagination, and aggregate counts are handled server-side, so results remain correct across the complete Contacts dataset rather than only the visible page.
- Existing time-range search, header sorting, mobile layout, and selection behavior are preserved.