### PR TITLE
List only commands that are enabled in cmd response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. The format loosely foll
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to
 semantic versioning.
 
+## [Unreleased]
+
+### Fixed
+
+- `cmd` no longer lists commands that are disabled in config
+
 ## [1.0.0] — 2026-08-07
 
 v1.0.0 marks the first stable release. It adds zero-hop neighbor discovery, a

--- a/modules/commands/base_command.py
+++ b/modules/commands/base_command.py
@@ -543,6 +543,13 @@ class BaseCommand(ABC):
         # Check if channel matches allowed list
         return message_channel_normalized in allowed_normalized
 
+    def is_enabled(self) -> bool:
+        """Return whether this command is enabled per config."""
+        for attr_name, attr_val in vars(self).items():
+            if attr_name.endswith('_enabled') and isinstance(attr_val, bool):
+                 return attr_val
+        return True
+
     def can_execute(self, message: MeshMessage, skip_channel_check: bool = False) -> bool:
         """Check if this command can be executed with the given message.
 

--- a/modules/commands/base_command.py
+++ b/modules/commands/base_command.py
@@ -543,13 +543,6 @@ class BaseCommand(ABC):
         # Check if channel matches allowed list
         return message_channel_normalized in allowed_normalized
 
-    def is_enabled(self) -> bool:
-        """Return whether this command is enabled per config."""
-        for attr_name, attr_val in vars(self).items():
-            if attr_name.endswith('_enabled') and isinstance(attr_val, bool):
-                 return attr_val
-        return True
-
     def can_execute(self, message: MeshMessage, skip_channel_check: bool = False) -> bool:
         """Check if this command can be executed with the given message.
 

--- a/modules/commands/cmd_command.py
+++ b/modules/commands/cmd_command.py
@@ -97,6 +97,8 @@ class CmdCommand(BaseCommand):
         for cmd_name, cmd_instance in self.bot.command_manager.commands.items():
             # Skip system commands without keywords (like greeter)
             if hasattr(cmd_instance, 'keywords') and cmd_instance.keywords:
+                if hasattr(cmd_instance, 'is_enabled') and not cmd_instance.is_enabled():
+                    continue
                 if not self._is_command_valid_for_channel(cmd_name, cmd_instance, message):
                     continue
                 all_commands.append(cmd_name)

--- a/modules/commands/cmd_command.py
+++ b/modules/commands/cmd_command.py
@@ -97,7 +97,8 @@ class CmdCommand(BaseCommand):
         for cmd_name, cmd_instance in self.bot.command_manager.commands.items():
             # Skip system commands without keywords (like greeter)
             if hasattr(cmd_instance, 'keywords') and cmd_instance.keywords:
-                if hasattr(cmd_instance, 'is_enabled') and not cmd_instance.is_enabled():
+                section_name = cmd_instance._derive_config_section_name()
+                if cmd_instance.get_config_value(section_name, "enabled", "false", bool) == "false":
                     continue
                 if not self._is_command_valid_for_channel(cmd_name, cmd_instance, message):
                     continue

--- a/tests/commands/test_cmd_command.py
+++ b/tests/commands/test_cmd_command.py
@@ -2,17 +2,14 @@
 
 import pytest
 
+from modules.commands.alert_command import AlertCommand
 from modules.commands.cmd_command import CmdCommand
+from modules.commands.ping_command import PingCommand
+from modules.commands.sports_command import SportsCommand
+from modules.commands.trace_command import TraceCommand
+from modules.commands.wx_command import WxCommand
 from tests.conftest import mock_message
-from dataclasses import dataclass
 
-@dataclass
-class MockCmdObject:
-    enabled: bool
-    keywords: str
-
-    def is_enabled(self):
-        return self.enabled
 
 class TestCmdCommand:
     """Tests for CmdCommand."""
@@ -36,14 +33,25 @@ class TestCmdCommand:
     async def test_is_not_listed_when_sports_cmd_disabled(self, command_mock_bot):
         command_mock_bot.config.add_section("Cmd_Command")
         command_mock_bot.config.set("Cmd_Command", "enabled", "true")
+        command_mock_bot.config.add_section("Ping_Command")
+        command_mock_bot.config.set("Ping_Command", "enabled", "true")
+        command_mock_bot.config.add_section("Wx_Command")
+        command_mock_bot.config.set("Wx_Command", "enabled", "true")
+        command_mock_bot.config.add_section("Sports_Command")
+        command_mock_bot.config.set("Sports_Command", "enabled", "false")
+        command_mock_bot.config.add_section("Trace_Command")
+        command_mock_bot.config.set("Trace_Command", "enabled", "true")
+        command_mock_bot.config.add_section("Alert_Command")
+        command_mock_bot.config.set("Alert_Command", "enabled", "true")
+
         command_mock_bot.command_manager.keywords = {}
         command_mock_bot.command_manager.commands = {
-            'test': MockCmdObject(enabled=True, keywords=['test']),
-            'ping': MockCmdObject(enabled=True, keywords=['ping']),
-            'wx': MockCmdObject(enabled=True, keywords=['wx']),
-            'sports': MockCmdObject(enabled=False, keywords=['sports']),
-            'trace': MockCmdObject(enabled=True, keywords=['trace']),
-            'alert': MockCmdObject(enabled=True, keywords=['alert'])}
+            'ping': PingCommand(command_mock_bot),
+            'wx': WxCommand(command_mock_bot),
+            'sports': SportsCommand(command_mock_bot),
+            'trace': TraceCommand(command_mock_bot),
+            'alert': AlertCommand(command_mock_bot)
+        }
 
         cmd = CmdCommand(command_mock_bot)
         msg = mock_message(content="cmd", is_dm=True)
@@ -51,7 +59,6 @@ class TestCmdCommand:
         call_args = command_mock_bot.command_manager.send_response.call_args
 
         assert result is True
-        assert 'test' in call_args[0][1]
         assert 'ping' in call_args[0][1]
         assert 'wx' in call_args[0][1]
         assert 'sports' not in call_args[0][1]
@@ -119,8 +126,8 @@ class TestCmdCommand:
         commands = {}
         for i in range(25):
             name = f"longcommandname{i:02d}"
-            mock_cmd = type("MockCmd", (), {"keywords": [name]})()
-            commands[name] = mock_cmd
+            commands[name] = CmdCommand(command_mock_bot)
+            command_mock_bot.config.add_section(name.title() + "_Command")
         command_mock_bot.command_manager.commands = commands
         cmd = CmdCommand(command_mock_bot)
         # "Available commands: " = 20 chars; "longcommandnameNN" = 17 chars; ", " = 2 chars

--- a/tests/commands/test_cmd_command.py
+++ b/tests/commands/test_cmd_command.py
@@ -4,7 +4,15 @@ import pytest
 
 from modules.commands.cmd_command import CmdCommand
 from tests.conftest import mock_message
+from dataclasses import dataclass
 
+@dataclass
+class MockCmdObject:
+    enabled: bool
+    keywords: str
+
+    def is_enabled(self):
+        return self.enabled
 
 class TestCmdCommand:
     """Tests for CmdCommand."""
@@ -23,6 +31,32 @@ class TestCmdCommand:
         cmd = CmdCommand(command_mock_bot)
         msg = mock_message(content="cmd", is_dm=True)
         assert cmd.can_execute(msg) is False
+
+    @pytest.mark.asyncio
+    async def test_is_not_listed_when_sports_cmd_disabled(self, command_mock_bot):
+        command_mock_bot.config.add_section("Cmd_Command")
+        command_mock_bot.config.set("Cmd_Command", "enabled", "true")
+        command_mock_bot.command_manager.keywords = {}
+        command_mock_bot.command_manager.commands = {
+            'test': MockCmdObject(enabled=True, keywords=['test']),
+            'ping': MockCmdObject(enabled=True, keywords=['ping']),
+            'wx': MockCmdObject(enabled=True, keywords=['wx']),
+            'sports': MockCmdObject(enabled=False, keywords=['sports']),
+            'trace': MockCmdObject(enabled=True, keywords=['trace']),
+            'alert': MockCmdObject(enabled=True, keywords=['alert'])}
+
+        cmd = CmdCommand(command_mock_bot)
+        msg = mock_message(content="cmd", is_dm=True)
+        result = await cmd.execute(msg)
+        call_args = command_mock_bot.command_manager.send_response.call_args
+
+        assert result is True
+        assert 'test' in call_args[0][1]
+        assert 'ping' in call_args[0][1]
+        assert 'wx' in call_args[0][1]
+        assert 'sports' not in call_args[0][1]
+        assert 'trace' in call_args[0][1]
+        assert 'alert' in call_args[0][1]
 
     @pytest.mark.asyncio
     async def test_execute_returns_command_list(self, command_mock_bot):


### PR DESCRIPTION
## What this changes

This adds a check to ensure a command is enabled when the list of commands are gathered for `cmd`. 

## Why

Currently if a command is disabled in `config.ini` (the `sports` command in my case), the disabled command still gets listed in the output of `cmd`. 

## Testing

I made the changes to the running copy of `meshcode-bot` and verified the output of `cmd`.

## Checklist

- [x] Branched from `dev` and targeting `dev`
- [x] `make test` passes
- [x] `make lint` passes (ruff + mypy)
- [ ] ~Frontend lint passes if templates changed (`npm run lint:frontend`)~
- [ ] ~Tests added or updated for behavior changes~
- [x] `CHANGELOG.md` updated under `## [Unreleased]` if user-visible
- [ ] ~Config changes are reflected in `config.ini.example` (and the minimal/quickstart
      templates where relevant) — CI validates these with `validate_config.py --strict`~
- [ ] ~New docs pages are added to `nav:` in `mkdocs.yml`~
- [ ] ~Any new command justifies its airtime and defaults conservatively~
