### PR TITLE
Add aliases for `cmd` to reduce ambiguity

### DIFF
--- a/modules/commands/cmd_command.py
+++ b/modules/commands/cmd_command.py
@@ -15,7 +15,7 @@ class CmdCommand(BaseCommand):
 
     # Plugin metadata
     name = "cmd"
-    keywords = ['cmd', 'commands']
+    keywords = ['cmd', 'cmds', 'command', 'commands']
     description = "Lists available commands in compact format"
     category = "basic"
 


### PR DESCRIPTION
## What this changes

This change adds the `cmds` and `command` aliases for `cmd`.

## Why

This is mostly to remove ambiguity for the end user. The original command and alias used both singular (`cmd`) and plural (`commands`). User may get confused and frustrated when `cmds` does not work and thinks that this is valid because they wish to see all available commands. The same way that `commands` may be confusing since the actual command is singular. So adding `cmds` and `command` is fairly minor to avoid user frustration.

## Testing

Again, such a minor change was tested on a running instance of `meshcore-bot`. 

## Checklist

- [x] Branched from `dev` and targeting `dev`
- [ ] `make test` passes
- [ ] `make lint` passes (ruff + mypy)
- [ ] ~Frontend lint passes if templates changed (`npm run lint:frontend`)~
- [ ] ~Tests added or updated for behavior changes~
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` if user-visible
- [ ] ~Config changes are reflected in `config.ini.example` (and the minimal/quickstart
      templates where relevant) — CI validates these with `validate_config.py --strict`~
- [ ] ~New docs pages are added to `nav:` in `mkdocs.yml`~
- [ ] ~Any new command justifies its airtime and defaults conservatively~
