### PR TITLE
Add traceback info for failed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,8 @@ semantic versioning.
   that had never been time-synced was the *first* candidate for eviction. Unknown
   staleness is no longer grounds for removal.
 
+- Add traceback information to errors gathered from command executions
+
 ### Changed
 
 - Response templates are parsed by a character-by-character state machine rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,10 @@ semantic versioning.
   that had never been time-synced was the *first* candidate for eviction. Unknown
   staleness is no longer grounds for removal.
 
-- Add traceback information to errors gathered from command executions
+- Command execution failures log a full traceback instead of a bare exception
+  message, so the failing file and line are visible without reproducing the error.
+  The reply sent over the mesh is unchanged — it still carries only the exception
+  text, with no filesystem path and no extra airtime.
 
 ### Changed
 

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -7,6 +7,7 @@ Handles all bot commands, keyword matching, and response generation
 import asyncio
 import random
 import time
+import traceback
 from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
@@ -2173,9 +2174,16 @@ class CommandManager:
                             self.logger.debug(f"Failed to capture command data for web viewer: {e}")
 
                 except Exception as e:
-                    self.logger.error(f"Error executing command '{command_name}': {e}")
+                    tb = traceback.TracebackException.from_exception(e)
+
+                    # Grab the last frame in the stack trace (where the error occurred)
+                    last_frame = list(tb.stack)[-1]
+                    file_name = last_frame.filename
+                    line_number = last_frame.lineno
+                    err_desc = f"{e} ({file_name}:{line_number})"
+                    self.logger.error(f"Error executing command '{command_name}': {err_desc}")
                     # Send error message to user
-                    error_msg = command.translate('errors.execution_error', command=command_name, error=str(e))
+                    error_msg = command.translate('errors.execution_error', command=command_name, error=err_desc)
                     await self.send_response(message, error_msg)
 
                     # Record command execution in stats database (error response was sent)

--- a/modules/command_manager.py
+++ b/modules/command_manager.py
@@ -7,7 +7,6 @@ Handles all bot commands, keyword matching, and response generation
 import asyncio
 import random
 import time
-import traceback
 from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
@@ -2174,16 +2173,11 @@ class CommandManager:
                             self.logger.debug(f"Failed to capture command data for web viewer: {e}")
 
                 except Exception as e:
-                    tb = traceback.TracebackException.from_exception(e)
-
-                    # Grab the last frame in the stack trace (where the error occurred)
-                    last_frame = list(tb.stack)[-1]
-                    file_name = last_frame.filename
-                    line_number = last_frame.lineno
-                    err_desc = f"{e} ({file_name}:{line_number})"
-                    self.logger.error(f"Error executing command '{command_name}': {err_desc}")
+                    # exception() carries the traceback into the log; the reply below stays
+                    # str(e) so no filesystem path or extra airtime goes out over the mesh.
+                    self.logger.exception(f"Error executing command '{command_name}': {e}")
                     # Send error message to user
-                    error_msg = command.translate('errors.execution_error', command=command_name, error=err_desc)
+                    error_msg = command.translate('errors.execution_error', command=command_name, error=str(e))
                     await self.send_response(message, error_msg)
 
                     # Record command execution in stats database (error response was sent)

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -1098,3 +1098,52 @@ class TestGetMaxMessageLength:
             m_len = mgr.get_max_message_length(msg)
             b_len = cmd.get_max_message_length(msg)
             assert m_len == b_len, (bot_name, username, is_dm, reply_scope, m_len, b_len)
+
+
+class TestExecuteCommandsErrorPath:
+    """The `except Exception` branch in execute_commands (PR #243)."""
+
+    @staticmethod
+    def _failing_command(exc):
+        command = MagicMock()
+        command.is_channel_allowed = Mock(return_value=True)
+        command.should_execute = Mock(return_value=True)
+        command.get_response_format = Mock(return_value=None)
+        command.can_execute_now = Mock(return_value=True)
+        command.requires_internet = False
+        command.cooldown_seconds = 0
+        command.last_response = None
+        command._record_execution = Mock()
+        command.execute = AsyncMock(side_effect=exc)
+        command.translate = Mock(side_effect=lambda key, **kw: f"{key}: {kw['error']}")
+        return command
+
+    @pytest.mark.asyncio
+    async def test_failure_is_logged_with_traceback(self, cm_bot):
+        manager = make_manager(cm_bot, commands={"boom": self._failing_command(RuntimeError("kaboom"))})
+        manager.send_response = AsyncMock(return_value=True)
+
+        await manager.execute_commands(mock_message(content="!boom", is_dm=True))
+
+        # logger.exception, not logger.error — the traceback is the whole point.
+        cm_bot.logger.exception.assert_called_once()
+        assert "kaboom" in cm_bot.logger.exception.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_mesh_reply_carries_only_the_exception_text(self, cm_bot):
+        """The reply goes out over RF, so it must not carry a filesystem path.
+
+        An earlier revision of #243 interpolated `file:line` from the traceback into
+        both the log line and this reply, which leaked the install path over the air
+        and spent airtime on the error path, where retries are most likely.
+        """
+        command = self._failing_command(RuntimeError("kaboom"))
+        manager = make_manager(cm_bot, commands={"boom": command})
+        manager.send_response = AsyncMock(return_value=True)
+
+        await manager.execute_commands(mock_message(content="!boom", is_dm=True))
+
+        assert command.translate.call_args.kwargs["error"] == "kaboom"
+        sent = manager.send_response.await_args.args[1]
+        assert sent == "errors.execution_error: kaboom"
+        assert ".py" not in sent and "command_manager" not in sent


### PR DESCRIPTION
## What this changes

Add info from the last frame on a traceback when a command fails

## Why

Because I am getting tired of seeing the error but not knowing where in the darn file the error occured! (and sometimes which file)

## Testing

Again, tested on my running instance. 

## Checklist

- [x] Branched from `dev` and targeting `dev`
- [ ] `make test` passes
- [x] `make lint` passes (ruff + mypy)
- [ ] ~Frontend lint passes if templates changed (`npm run lint:frontend`)~
- [ ] Tests added or updated for behavior changes
- [x] `CHANGELOG.md` updated under `## [Unreleased]` if user-visible
- [ ] ~Config changes are reflected in `config.ini.example` (and the minimal/quickstart
      templates where relevant) — CI validates these with `validate_config.py --strict`~
- [ ] ~New docs pages are added to `nav:` in `mkdocs.yml`~
- [ ] ~Any new command justifies its airtime and defaults conservatively~
