### PR TITLE
docs: Update docs concerning waev.app broker authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ semantic versioning.
   and Configuration now sit under a single **Settings** gear menu, leaving Dashboard,
   Real-time, Contacts, Mesh Graph and Logs on the bar. The current page is highlighted,
   including the gear when a settings page is open.
+- Added notes on connecting to waev.app MQTT brokers to the `packet_capture.md` file.
 
 ### Added
 

--- a/docs/packet-capture.md
+++ b/docs/packet-capture.md
@@ -154,6 +154,13 @@ jwt_renewal_interval = 43200      # Default proactive refresh cadence (12 hours)
 # mqtt1_jwt_renewal_interval = 1800
 ```
 
+**Note**: When connecting to waev.app brokers the default settings will cause the connection not to authenticate properly. Please use the following settings on the MQTT connection for the waev.app brokers.
+
+```ini
+mqttN_jwt_ttl_seconds = 3600
+mqttN_jwt_renewal_interval = 3500
+```
+
 ---
 
 ## Packet Format
@@ -267,6 +274,8 @@ Common issues:
    ```
 3. **Check authentication** - Verify JWT token generation
 4. **Check logs** - Look for connection errors
+
+**Note**: If the MQTT connection that is failing is attempting to connect to waev.app brokers, please see the [Status Publishing and MQTT auth (JWT)](#status-publishing-and-mqtt-auth-jwt) section.
 
 ### No Packets Being Published
 


### PR DESCRIPTION

## What this changes

Just a couple quick notes related to waev.app MQTT broker authentication.

## Why

So others don't need to have specialized knowledge and magical incantations to make connections to the waev.app brokers.

## Checklist

- [x] Branched from `dev` and targeting `dev`
- [ ] ~`make test` passes~
- [ ] ~`make lint` passes (ruff + mypy)~
- [ ] ~Frontend lint passes if templates changed (`npm run lint:frontend`)~
- [ ] ~Tests added or updated for behavior changes~
- [x] `CHANGELOG.md` updated under `## [Unreleased]` if user-visible
- [ ] ~Config changes are reflected in `config.ini.example` (and the minimal/quickstart
      templates where relevant) — CI validates these with `validate_config.py --strict`~
- [ ] ~New docs pages are added to `nav:` in `mkdocs.yml`~
- [ ] ~Any new command justifies its airtime and defaults conservatively~
