### PR TITLE
feat(scheduler): add flexible cron format for scheduled messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,18 @@ semantic versioning.
   options and previews the next five runs; entries the bot cannot run are shown as
   **Not scheduled** with the reason rather than hidden. It edits the same config section
   the bot already uses, so there is no second source of truth.
+- **Flexible cron format for `[Scheduled_Messages]`**, alongside standard 5-field cron.
+  Fields can appear in any order using suffixes (`9h`, `30m`, `15d`, `3w` for ISO week)
+  plus month/day-of-week names, so schedules that plain cron cannot express — "the 4th
+  Tuesday of the month" (`4th tue 19:00`) or "the last Friday" (`last fri`) — no longer
+  need a hand-rolled day-of-month list that drifts across months of different lengths.
+  Optional `start:YYYY-MM-DD` / `end:YYYY-MM-DD` bound a schedule to a date range. The
+  web viewer's schedule builder gets a matching "Flexible (cron)" mode, and the edit
+  modal now detects which mode a stored schedule belongs to instead of always opening in
+  Advanced. Because `:` is the INI key/value separator, a flexible-cron key containing
+  an HH:MM time is stored in `config.ini` with `:` encoded as `!` (e.g.
+  `4th tue 14!00 jan-oct = ...`) and decoded back on every read; `HHMM` without a colon
+  needs no encoding.
 - Documented installing with `pipx`, which sidesteps PEP 668 on Debian 12+, Ubuntu
   23.04+, Fedora and Arch (#222), including where `config.ini`, the database and
   `local/` live — everything resolves relative to the config file's directory, so an

--- a/config.ini.example
+++ b/config.ini.example
@@ -111,7 +111,7 @@ message_correlation_timeout = 10.0
 enable_enhanced_correlation = true
 
 # Bot node ID (leave empty for auto-assignment)
-node_id = 
+node_id =
 
 # Command prefix (optional). Single prefix (!), multiple decorative (!~.),
 # or comma-separated (!, ~, .). First is shown in help/docs.
@@ -187,7 +187,7 @@ dm_flood_after = 2
 # Timezone for bot operations
 # Use standard timezone names (e.g., America/New_York, Europe/London, UTC)
 # Leave empty to use system timezone
-timezone = 
+timezone =
 
 # Bot location for geographic proximity calculations and astronomical data
 # Default latitude for bot location (decimal degrees)
@@ -349,13 +349,13 @@ auto_detect_language = false
 # - Public keys MUST be exactly 64 hexadecimal characters (ed25519 format)
 # - Invalid formats will be rejected with error logs
 # - Empty or whitespace-only values disable admin access
-# - Keys are case-insensitive (normalized to lowercase)  
+# - Keys are case-insensitive (normalized to lowercase)
 #
 # Format: comma-separated list of 64-character hex public keys (without spaces)
 # Example: f5d2b56d19b24412756933e917d4632e088cdd5daeadc9002feca73bf5d2b56d,1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 #
 # IMPORTANT: Leave blank to disable all admin commands. Set your actual admin pubkey(s) here.
-admin_pubkeys = 
+admin_pubkeys =
 
 # Commands that require admin access (comma-separated)
 # These commands will only work for users in the admin_pubkeys list
@@ -368,13 +368,13 @@ admin_commands = repeater,webviewer,reload,channelpause,neighbors
 # Format: command_name = alternative_file_name
 # The alternative_file_name should be the name of a Python file (without .py extension)
 # in the modules/commands/alternatives/ directory
-# 
+#
 # Example: To use an alternative weather plugin for international users:
 # wx = wx_international
-# 
+#
 # This will replace the default wx command with the plugin from
 # modules/commands/alternatives/wx_international.py
-# 
+#
 # Note: The alternative plugin must have the same 'name' metadata as the command
 # it's replacing, or the override will use the alternative plugin's name instead.
 #
@@ -433,7 +433,7 @@ companion_min_inactive_days = 30
 #
 # To use a literal backslash + n, use \\n (double backslash + n)
 # Other escape sequences: \t (tab), \r (carriage return), \\ (literal backslash)
-# 
+#
 # Available placeholders (mesh network info - same as Scheduled_Messages):
 # Total counts (ever heard):
 # {total_contacts} - Total number of contacts ever heard
@@ -441,23 +441,23 @@ companion_min_inactive_days = 30
 # {total_companions} - Total number of companion devices ever heard
 # {total_roomservers} - Total number of roomserver devices ever heard
 # {total_sensors} - Total number of sensor devices ever heard
-# 
+#
 # Recent activity:
 # {recent_activity_24h} - Number of unique users active in last 24 hours
-# 
+#
 # Active in last 30 days (last_heard):
 # {total_contacts_30d} - Total contacts active (last_heard) in last 30 days
 # {total_repeaters_30d} - Total repeaters active (last_heard) in last 30 days
 # {total_companions_30d} - Total companions active (last_heard) in last 30 days
 # {total_roomservers_30d} - Total roomservers active (last_heard) in last 30 days
 # {total_sensors_30d} - Total sensors active (last_heard) in last 30 days
-# 
+#
 # New devices (first heard in last 7 days):
 # {new_companions_7d} - New companion devices first heard in last 7 days
 # {new_repeaters_7d} - New repeater devices first heard in last 7 days
 # {new_roomservers_7d} - New roomserver devices first heard in last 7 days
 # {new_sensors_7d} - New sensor devices first heard in last 7 days
-# 
+#
 # Legacy placeholders (for backward compatibility):
 # {repeaters} - Same as {total_repeaters}
 # {companions} - Same as {total_companions}
@@ -520,6 +520,10 @@ category.funfact = fun
 #       0 8 * * *     = every day at 08:00 (in [Bot] timezone)
 #       30 12 * * mon = every Monday at 12:30
 #       30 12 * * 0   = same (Monday) — see APScheduler note below
+#   - Flexible crontab using unordered fields with suffix identifiers (e.g. 9h,
+#     45m, 28d), month/day-of-week names (e.g. mon, thu, feb, nov), ordinate
+#     prefixes for days-of-week (e.g. 1st, 2nd, last). See scheduled-messages.md
+#     for complete description and examples.
 #   - Preset aliases (@yearly @annually @monthly @weekly @daily @midnight @hourly).
 #     These expand to the 5-field forms above; @weekly is Monday 00:00 (not Sunday).
 #   - Deprecated (still accepted, logs a warning): HHMM = daily at that 24h clock time
@@ -532,7 +536,7 @@ category.funfact = fun
 #
 # Newlines: use \n in the message for a line break (e.g. general:Line one\nLine two).
 # Literal backslash: use \\n for backslash+n; \\t for tab.
-# 
+#
 # Command output placeholder:
 #
 # {cmd:<command> [args]} runs a bot command and substitutes its reply text, so any
@@ -564,34 +568,34 @@ category.funfact = fun
 #     fires, the placeholder expands to nothing that round.
 #
 # Available placeholders for mesh network information:
-# 
+#
 # Total counts (ever heard):
 # {total_contacts} - Total number of contacts ever heard
 # {total_repeaters} - Total number of repeater devices ever heard
 # {total_companions} - Total number of companion devices ever heard
 # {total_roomservers} - Total number of roomserver devices ever heard
 # {total_sensors} - Total number of sensor devices ever heard
-# 
+#
 # Recent activity:
 # {recent_activity_24h} - Number of unique users active in last 24 hours
-# 
+#
 # Active in last 30 days (last_heard):
 # {total_contacts_30d} - Total contacts active (last_heard) in last 30 days
 # {total_repeaters_30d} - Total repeaters active (last_heard) in last 30 days
 # {total_companions_30d} - Total companions active (last_heard) in last 30 days
 # {total_roomservers_30d} - Total roomservers active (last_heard) in last 30 days
 # {total_sensors_30d} - Total sensors active (last_heard) in last 30 days
-# 
+#
 # New devices (first heard in last 7 days):
 # {new_companions_7d} - New companion devices first heard in last 7 days
 # {new_repeaters_7d} - New repeater devices first heard in last 7 days
 # {new_roomservers_7d} - New roomserver devices first heard in last 7 days
 # {new_sensors_7d} - New sensor devices first heard in last 7 days
-# 
+#
 # Legacy placeholders (for backward compatibility):
 # {repeaters} - Same as {total_repeaters}
 # {companions} - Same as {total_companions}
-# 
+#
 # Example with placeholders (cron):
 # 0 8 * * * = Public:Good morning! Network: {total_contacts} total ({total_repeaters} repeaters, {total_companions} companions). {new_repeaters_7d} new repeaters, {new_companions_7d} new companions in last 7d. {recent_activity_24h} active in 24h.
 # Example with 30-day active devices and new devices in 7d:
@@ -659,33 +663,33 @@ short_url_website_service = gd
 short_url_website = https://v.gd
 # API key. Optional for gd (unused for public v.gd/is.gd, appended as ?key= for
 # alternate hosts). Required for shlink, where it is sent as an X-Api-Key header.
-short_url_website_api_key = 
+short_url_website_api_key =
 
 # Weather API key (future feature)
-weather_api_key = 
+weather_api_key =
 
 # Weather update interval in seconds (future feature)
 weather_update_interval = 3600
 
 # Tide API key (future feature)
-tide_api_key = 
+tide_api_key =
 
 # Tide update interval in seconds (future feature)
 tide_update_interval = 1800
 
 # N2YO API key for satellite pass information
 # Get free key at: https://www.n2yo.com/login/
-n2yo_api_key = 
+n2yo_api_key =
 
 # AirNow API key for AQI data
 # Get free key at: https://docs.airnowapi.org/
-airnow_api_key = 
+airnow_api_key =
 
 # Forecast.Solar API key for solar forecast data
 # Get key at: https://forecast.solar/ (free tier works without key, paid tier for 3+ day forecasts)
 # Free tier: 2-day forecast, 1-hour resolution
 # Paid tier (14 EUR/year): 3-6 day forecast, 15-30 minute resolution
-forecast_solar_api_key = 
+forecast_solar_api_key =
 
 # Optional external repeater-prefix API for the prefix command.
 #
@@ -700,7 +704,7 @@ forecast_solar_api_key =
 # Fetched with a plain GET, must answer HTTP 200 with that JSON, 10s timeout.
 # "prefix" is upper-cased by the bot; "node_count" is an int; "node_names" a list.
 # Responses are cached for repeater_prefix_cache_hours below.
-repeater_prefix_api_url = 
+repeater_prefix_api_url =
 
 # Repeater prefix cache duration in hours
 # How long to cache prefix data before refreshing from API
@@ -1082,7 +1086,7 @@ path_selection_preset = balanced
 
 # Basic Settings
 # Geographic proximity calculation method
-# simple: Use proximity to bot location 
+# simple: Use proximity to bot location
 # path: Use proximity to previous/next nodes in the path for more realistic routing (default)
 proximity_method = path
 
@@ -1331,7 +1335,7 @@ enabled = false
 # Comma-separated list to restrict to specific channels (only greeter command works there)
 # Example: channels = general,welcome,newbies
 # If not specified, uses the channels from [Channels] monitor_channels setting
-# channels = 
+# channels =
 
 # Greeting message template (default for all channels)
 # Available fields: {sender} - the user's name/ID
@@ -1349,7 +1353,7 @@ greeting_message = Welcome to the mesh, @[{sender}]!
 # channel name. (So avoid text like ", wx: sunny" if wx is also a channel.)
 # Multi-part greetings are supported per channel using pipe (|) separator
 # Leave empty to use greeting_message for all channels
-channel_greetings = 
+channel_greetings =
 
 # Per-channel greetings (tracking behavior)
 # false: Greet each user only once globally (default - user gets one greeting total)
@@ -1434,7 +1438,7 @@ enabled = false
 # Format: comma-separated list of 64-character hex public keys (without spaces)
 # Example: f5d2b56d19b24412756933e917d4632e088cdd5daeadc9002feca73bf5d2b56d
 # Leave empty to only use Admin_ACL members
-announcements_acl = 
+announcements_acl =
 
 # Default channel for announcements when no channel is specified
 # Announcements will be sent to this channel if no channel is provided
@@ -1772,7 +1776,7 @@ mesh_graph_cache_seconds = 30
 #
 # Note: Only hashtag channels work here - custom channels with private keys
 # must be added to the radio itself.
-decode_hashtag_channels = 
+decode_hashtag_channels =
 
 ####################################################################################################
 #                                                                                                  #
@@ -1788,7 +1792,7 @@ enabled = false
 # Output file for packet data (optional)
 # Leave empty to disable file output
 # Packets will be written as JSON lines
-output_file = 
+output_file =
 
 # Verbose output (show JSON packet data in logs)
 # true: Show packet data in logs
@@ -1920,7 +1924,7 @@ neighbors_self_scopes =
 owner_public_key =
 
 # Owner email address
-owner_email = 
+owner_email =
 
 # Private key file path for auth token generation (fallback if device signing unavailable)
 # Optional - on-device signing is preferred
@@ -1928,7 +1932,7 @@ owner_email =
 # Required only if device doesn't support on-device signing or auth_token_method = python
 # Note: If not provided and auth_token_method = python, the service will attempt to fetch
 # the private key from the device automatically
-private_key_path = 
+private_key_path =
 
 # Auth token signing method
 # device: Try on-device signing first, fallback to Python signing (default, recommended)
@@ -2024,8 +2028,8 @@ mqtt2_token_audience = mqtt-eu-v1.letsmesh.net
 mqtt2_topic_status = meshcore/{IATA}/{PUBLIC_KEY}/status
 mqtt2_topic_packets = meshcore/{IATA}/{PUBLIC_KEY}/packets
 mqtt2_websocket_path = /mqtt
-mqtt2_client_id = 
-mqtt2_upload_packet_types = 
+mqtt2_client_id =
+mqtt2_upload_packet_types =
 
 # Stats and status publishing
 # Enable stats in status messages
@@ -2062,7 +2066,7 @@ api_url = https://map.meshcore.dev/api/v1/uploader/node
 # If not provided, the service will attempt to fetch the private key from the device
 # Supports 64-byte orlp format (128 hex chars) or 32-byte seed (64 hex chars)
 # Required only if device doesn't support private key export
-private_key_path = 
+private_key_path =
 
 # Minimum time between re-uploads of same node (seconds)
 # Prevents uploading the same node too frequently to avoid API spam
@@ -2094,10 +2098,10 @@ weather_alarm = 6:00
 
 # Bot position for weather forecasts and alerts
 # Latitude in decimal degrees
-my_position_lat = 
+my_position_lat =
 
 # Longitude in decimal degrees
-my_position_lon = 
+my_position_lon =
 
 # Channel for daily weather forecasts
 # Weather forecasts will be sent to this channel

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Documentation for the MeshCore bot: setup, configuration, commands, and services
 | [Feed Management](FEEDS.md) | RSS/REST feeds and posting to channels |
 | [Web Viewer](web-viewer.md) | Web-based data viewer and API |
 | [Custom command website](command-reference-website.md) | Generate an HTML command reference for your users |
+| [Scheduled messages](schedule-messages.md) | How message schedules work |
 
 ## Service Plugins
 

--- a/docs/schedule-messages.md
+++ b/docs/schedule-messages.md
@@ -9,7 +9,7 @@ The scheduled message subsystem uses APScheduler (a Python scheduling library) t
 You can specify schedules in three ways:
 1. **Simplified modes** (web UI only) — templates for common patterns like daily, weekly, or interval-based schedules
 2. **Standard cron** — the traditional 5-field cron syntax used in Unix/Linux systems
-3. **Flexible cron** — a more human-readable format that allows fields in any order with intuitive suffixes
+3. **Flexible cron** — a more human-readable format that allows fields in any order with intuitive qualifiers
 
 All three approaches ultimately create the same underlying schedule representation, but offer different levels of convenience and expressiveness.
 
@@ -163,6 +163,8 @@ Flexible cron is a more readable alternative to standard cron that allows you to
 
 **Note:** Use three-letter month and day-of-week names (`jan`, `mon`) for clarity. While numeric values are technically supported, names are strongly preferred to avoid confusion.
 
+**Note:** The use of `*` for the month or day of week is invalid when using a flexible cron entry. Not specifying a month or day of week is the same as `*` for the field.
+
 ### Time Specification
 
 You can specify time in several ways:
@@ -202,7 +204,7 @@ last fri     → Last Friday of the month
 last         → Last day of the month (28th, 29th, 30th, or 31st depending on the month)
 ```
 
-This is particularly useful for end-of-month schedules without worrying about month length.
+This is particularly useful for end-of-month schedules without worrying about the number of days in a month.
 
 **Examples:**
 - `last 15:00` → 3:00 PM on the last day of every month
@@ -210,7 +212,9 @@ This is particularly useful for end-of-month schedules without worrying about mo
 
 ### Date Range Constraints
 
-You can limit when a schedule is active using start and end dates. This is useful for seasonal schedules or time-limited events.
+You can limit when a schedule is active using start and end dates. This is useful for seasonal schedules or time-limited events. The start and end date needs to be specified as an ISO 8601 date (YYYY-MM-DD).
+
+Special case when using the year of '0000'. The year will be replaced with the current year. This allows the constraint to be reused each year without having to create or update the scheduled message entry every year.
 
 **Start date only:**
 ```
@@ -230,14 +234,13 @@ mon 14:00 start:2026-06-01 end:2026-12-31
 ```
 Schedule runs only from June 1 through December 31, 2026.
 
-**Date format:** Use ISO 8601 format: `YYYY-MM-DD`
-
 **Examples:**
 - `4th tue 19:00 jan-oct start:2026-01-01 end:2026-12-31` → 4th Tuesday at 7 PM, January–October 2026 only
 - `fri 18:00 start:2026-06-01` → Every Friday at 6 PM, starting June 1, 2026
 - `1st mon 09:00 end:2026-05-31` → First Monday at 9 AM, until May 31, 2026
+- `sun 09:00 start:0000-06-01 end:0000-07-31` → Every Sunday at 9 AM, starting June 1 and ending July 31 of every year
 
-### Examples
+### Flexible Cron Examples
 
 **Every 4th Tuesday at 7:00 PM, January through October:**
 ```
@@ -286,16 +289,16 @@ trigger to fire every minute.
 
 ### Field Resolution Order
 
-When the flexible cron parser processes your expression:
+When the flexible cron parser processes your expression the following order is used to identify portions of the expression:
 
 1. **Time** is extracted first (HH:MM or HHMM pattern)
 2. If no combined time, **hour** (`Nh`) and **minute** (`Nm`) are parsed separately
-3. **Month** names/numbers are identified
-4. **Day of month** (with `d` suffix) is parsed
+3. **Day of month** (with `d` suffix) is parsed
+4. **Month** names/numbers are identified
 5. **Week** (with `w` suffix) is parsed
 6. **Day of week** with optional ordinal prefix is parsed last
 
-Fields not specified default to `*` (any value).
+Fields not specified default to `*` (all values).
 
 ---
 

--- a/docs/schedule-messages.md
+++ b/docs/schedule-messages.md
@@ -1,0 +1,485 @@
+# Scheduled Message Time Specifications
+
+This document describes how to specify when scheduled messages should be sent, both through the web viewer UI and directly in the `config.ini` file.
+
+## Overview
+
+The scheduled message subsystem uses APScheduler (a Python scheduling library) to maintain schedules and trigger messages at the specified times. Messages are sent to a designated channel at the configured frequency.
+
+You can specify schedules in three ways:
+1. **Simplified modes** (web UI only) — templates for common patterns like daily, weekly, or interval-based schedules
+2. **Standard cron** — the traditional 5-field cron syntax used in Unix/Linux systems
+3. **Flexible cron** — a more human-readable format that allows fields in any order with intuitive suffixes
+
+All three approaches ultimately create the same underlying schedule representation, but offer different levels of convenience and expressiveness.
+
+---
+
+## Simplified Schedule Modes (Web UI)
+
+The web viewer provides pre-built templates for common scheduling patterns. When you select one of these modes, the UI builds the appropriate cron expression for you.
+
+### Daily at Specific Time
+
+Send a message every day at a specific time.
+
+**Example:** Daily at 8:00 AM
+- **Stored as:** `0 8 * * *`
+- **When it fires:** Every day at 8:00 AM
+
+### Weekly on Specific Days
+
+Send a message on specific days of the week at a chosen time.
+
+**Example:** Every Monday, Wednesday, and Friday at 7:00 PM
+- **Stored as:** `0 19 * * 1,3,5`
+- **When it fires:** 7:00 PM on Monday, Wednesday, and Friday
+
+**Day numbering:** In standard cron format, days are numbered 0=Monday through 6=Sunday. The web UI handles this for you.
+
+### Every N Hours
+
+Send a message at regular hourly intervals.
+
+**Example:** Every 6 hours
+- **Stored as:** `0 */6 * * *`
+- **When it fires:** Midnight, 6 AM, noon, 6 PM
+
+### Every N Minutes
+
+Send a message at regular minute intervals.
+
+**Example:** Every 30 minutes
+- **Stored as:** `*/30 * * * *`
+- **When it fires:** On the hour and half-hour (e.g., 8:00, 8:30, 9:00, 9:30...)
+
+---
+
+## Standard Cron Format
+
+Standard cron expressions use five fields separated by spaces:
+
+```
+minute hour day-of-month month day-of-week
+```
+
+### Field Definitions
+
+| Field         | Valid Values        | Examples                  |
+|---------------|---------------------|---------------------------|
+| minute        | 0–59                | `0`, `15`, `30`, `*/5`    |
+| hour          | 0–23                | `8`, `14`, `20`, `*/2`    |
+| day-of-month  | 1–31                | `1`, `15`, `*/2`          |
+| month         | 1–12 or jan–dec     | `jan`, `mar-jul`, `6` (discouraged) |
+| day-of-week   | 0–6 or mon–sun      | `mon`, `wed,fri`, `0` (discouraged) |
+
+**Important:**
+- Day-of-week numbering is 0=Monday through 6=Sunday (APScheduler convention), not the traditional Unix cron 0=Sunday.
+- **Use three-letter month and day names** (`jan`, `mon`) instead of numbers to avoid confusion and improve readability.
+
+### Special Characters
+
+- `*` — matches any value (e.g., `*` in the month field means "every month")
+- `,` — list separator (e.g., `1,15` means "on the 1st and 15th")
+- `-` — range (e.g., `mon-fri` means "Monday through Friday")
+- `/` — step values (e.g., `*/15` means "every 15 units")
+
+### Preset Aliases
+
+Instead of five fields, you can use a preset alias:
+
+| Preset       | Equivalent Cron | Description                |
+|--------------|-----------------|----------------------------|
+| `@yearly`    | `0 0 1 1 *`     | Once a year (Jan 1, midnight) |
+| `@annually`  | `0 0 1 1 *`     | Same as @yearly            |
+| `@monthly`   | `0 0 1 * *`     | First day of each month    |
+| `@weekly`    | `0 0 * * 0`     | Every Monday at midnight   |
+| `@daily`     | `0 0 * * *`     | Every day at midnight      |
+| `@midnight`  | `0 0 * * *`     | Same as @daily             |
+| `@hourly`    | `0 * * * *`     | Start of every hour        |
+
+### Examples
+
+**Every day at 9:30 AM:**
+```
+30 9 * * *
+```
+
+**Every weekday (Monday–Friday) at 6:00 PM:**
+```
+0 18 * * mon-fri
+```
+
+**First day of every month at noon:**
+```
+0 12 1 * *
+```
+
+**Every 15 minutes:**
+```
+*/15 * * * *
+```
+
+**Twice a day (6 AM and 6 PM):**
+```
+0 6,18 * * *
+```
+
+**Every Sunday at 8:00 AM during summer months (June–August):**
+```
+0 8 * jun-aug sun
+```
+
+---
+
+## Flexible Cron Format
+
+Flexible cron is a more readable alternative to standard cron that allows you to specify scheduling fields in any order using intuitive suffixes. This format is particularly useful when editing schedules directly in `config.ini` or when using the "Flexible (cron)" mode in the web UI.
+
+**Key advantage:** Flexible cron can express schedules that are impossible with standard cron, such as "the 4th Tuesday of each month" or "the last Friday of the month."
+
+### Key Features
+
+- **Any order:** Fields can appear in any sequence
+- **Optional fields:** Only specify what you need; omitted fields default to `*` (any value)
+- **Case-insensitive:** `MON`, `Mon`, and `mon` are all valid
+- **Readable time:** Use `HH:MM` format instead of separate hour/minute fields
+- **Ordinal day patterns:** Specify "2nd Tuesday" or "last Friday" — patterns that require complex workarounds in standard cron
+
+### Field Syntax
+
+| Component       | Suffix/Format | Examples                    |
+|-----------------|---------------|-----------------------------|
+| Time (combined) | `HH:MM` or `HHMM` | `14:30`, `0815`        |
+| Hour            | `h`           | `9h`, `14h`, `*/6h`         |
+| Minute          | `m`           | `30m`, `*/15m`              |
+| Day of month    | `d`           | `15d`, `1,15d`, `*/7d`      |
+| Month           | (bare name)   | `jan`, `feb-may`, `jun,jul,aug` |
+| Day of week     | (bare name)   | `mon`, `tue,thu`, `mon-fri` |
+| ISO week        | `w`           | `1w`, `3w`, `1-52w`         |
+| Ordinal + day   | `1st`–`5th`, `last` | `1st mon`, `last fri`, `4th tue` |
+| Start date      | `start:YYYY-MM-DD` | `start:2026-06-01`    |
+| End date        | `end:YYYY-MM-DD`   | `end:2026-12-31`      |
+
+**Note:** Use three-letter month and day-of-week names (`jan`, `mon`) for clarity. While numeric values are technically supported, names are strongly preferred to avoid confusion.
+
+### Time Specification
+
+You can specify time in several ways:
+
+**Combined HH:MM format:**
+```
+14:30        → 2:30 PM
+08:15        → 8:15 AM
+0815         → 8:15 AM (colon optional)
+```
+
+**Separate hour and minute:**
+```
+9h 30m       → 9:30 AM
+14h 0m       → 2:00 PM
+```
+
+**Hour or minute alone:**
+```
+9h           → Every day at 9:00 AM (minute defaults to 0)
+30m          → 30 minutes past every hour
+```
+
+### Day of Week with Ordinal
+
+You can specify "the Nth [day] of the month" — a powerful feature that standard cron cannot express directly:
+
+```
+1st mon      → First Monday of each month
+2nd tue      → Second Tuesday
+4th thu      → Fourth Thursday
+last fri     → Last Friday of the month
+```
+
+**Using "last" alone:**
+```
+last         → Last day of the month (28th, 29th, 30th, or 31st depending on the month)
+```
+
+This is particularly useful for end-of-month schedules without worrying about month length.
+
+**Examples:**
+- `last 15:00` → 3:00 PM on the last day of every month
+- `last jan,mar,may` → Last day of January, March, and May
+
+### Date Range Constraints
+
+You can limit when a schedule is active using start and end dates. This is useful for seasonal schedules or time-limited events.
+
+**Start date only:**
+```
+mon 14:00 start:2026-06-01
+```
+Schedule begins June 1, 2026 and continues indefinitely.
+
+**End date only:**
+```
+mon 14:00 end:2026-12-31
+```
+Schedule runs until December 31, 2026, then stops.
+
+**Both start and end:**
+```
+mon 14:00 start:2026-06-01 end:2026-12-31
+```
+Schedule runs only from June 1 through December 31, 2026.
+
+**Date format:** Use ISO 8601 format: `YYYY-MM-DD`
+
+**Examples:**
+- `4th tue 19:00 jan-oct start:2026-01-01 end:2026-12-31` → 4th Tuesday at 7 PM, January–October 2026 only
+- `fri 18:00 start:2026-06-01` → Every Friday at 6 PM, starting June 1, 2026
+- `1st mon 09:00 end:2026-05-31` → First Monday at 9 AM, until May 31, 2026
+
+### Examples
+
+**Every 4th Tuesday at 7:00 PM, January through October:**
+```
+4th tue 19:00 jan-oct
+```
+or
+```
+4th tue 1900 jan-oct
+```
+
+**Reminder on the 1st and 15th of each month at 2:30 PM:**
+```
+1,15d 14:30
+```
+
+**Every Monday morning at 9:00 AM:**
+```
+mon 09:00
+```
+
+**Every Wednesday during summer at noon:**
+```
+wed jun-aug 12:00
+```
+
+**Last Saturday of the month at 10:00 AM:**
+```
+last sat 10:00
+```
+
+**Weekly on Monday at 6:00 PM:**
+```
+mon 18:00
+```
+
+**Every 6 hours:**
+```
+*/6h 0m
+```
+
+**Note:** `0m` needs to be specified here to trigger at the top of the
+hour every 6 hours. If `0m` was not specified, then the result would be
+to trigger every minute for an hour every 6 hours. This is because without
+specifying the minute component it defaults to `*` which would cause the
+trigger to fire every minute.
+
+### Field Resolution Order
+
+When the flexible cron parser processes your expression:
+
+1. **Time** is extracted first (HH:MM or HHMM pattern)
+2. If no combined time, **hour** (`Nh`) and **minute** (`Nm`) are parsed separately
+3. **Month** names/numbers are identified
+4. **Day of month** (with `d` suffix) is parsed
+5. **Week** (with `w` suffix) is parsed
+6. **Day of week** with optional ordinal prefix is parsed last
+
+Fields not specified default to `*` (any value).
+
+---
+
+## Configuration File Format
+
+### Location
+
+Scheduled messages are stored in the `[Scheduled_Messages]` section of `config.ini`:
+
+```ini
+[Scheduled_Messages]
+schedule_expression = Channel:Message text
+```
+
+### Basic Format
+
+Each line defines one scheduled message:
+
+```ini
+schedule = channel:message
+```
+
+**Example:**
+```ini
+0 8 * * * = General:Good morning everyone!
+```
+
+This sends "Good morning everyone!" to the General channel every day at 8:00 AM.
+
+### Scoped Messages (Regional Flood)
+
+To limit message propagation to a specific region, use the scoped format:
+
+```ini
+schedule = channel:#scope:message
+```
+
+**Example:**
+```ini
+0 18 * * 5 = Public:#sea:ARES net starts in 30 minutes
+```
+
+This sends the message only within the `#sea` flood scope.
+
+### Using Flexible Cron in config.ini
+
+When using flexible cron with `HH:MM` time format, the colon (`:`) conflicts with the INI file's `key:value` separator. To work around this, the bot automatically encodes colons in schedule keys as exclamation marks (`!`) when writing to disk.
+
+**What you enter in the web UI:**
+```
+4th tue 14:00 jan-oct
+```
+
+**How it appears in config.ini:**
+```ini
+4th tue 14!00 jan-oct
+```
+
+**Important:** When manually editing `config.ini`, you must use `!` instead of `:` in the schedule key (the left side of the `=`). The bot will decode it back to `:` when loading. The message text (right side) can contain colons normally.
+
+If you use the `HHMM` format (without a colon), no encoding is needed:
+
+```ini
+4th tue 1400 jan-oct
+```
+
+### Escape Sequences
+
+The bot supports escape sequences in message text:
+
+| Sequence | Result          |
+|----------|-----------------|
+| `\n`     | Line break      |
+| `\t`     | Tab character   |
+| `\\`     | Literal backslash |
+
+**Example:**
+```ini
+0 9 * * * = General:Good morning!\nHave a great day!
+```
+
+This sends a two-line message.
+
+### Complete Examples
+
+**Daily morning message:**
+```ini
+0 8 * * * = General:Good morning! Today is a new day.
+```
+
+**Weekly ARES net reminder:**
+```ini
+0 18 * * 2 = ARES:#local:Net starts at 7 PM tonight
+```
+
+**Monthly first-of-month announcement:**
+```ini
+0 12 1 * * = Announcements:First of the month - time to check in!
+```
+
+**Flexible cron - 2nd and 4th Thursday at 7:30 PM:**
+```ini
+2nd,4th thu 19!30 = ARES:Meeting tonight
+```
+
+**Hourly status update:**
+```ini
+@hourly = Status:Hourly system check - all OK
+```
+
+---
+
+## Timezone Handling
+
+All scheduled messages use the timezone configured in the `[Bot]` section of `config.ini`:
+
+```ini
+[Bot]
+timezone = US/Eastern
+```
+
+If no timezone is set, the bot uses the system's local timezone.
+
+---
+
+## Command Placeholders in Scheduled Messages
+
+Scheduled messages can include dynamic content using command placeholders like `{cmd:wx}` or `{cmd:solar}`. However, these commands consume airtime on the mesh network, so there's a minimum interval restriction:
+
+**Minimum interval for messages with `{cmd:...}` placeholders: 15 minutes**
+
+If you try to schedule a message with a command placeholder more frequently than every 15 minutes, the web UI will reject it with an error.
+
+**Valid:**
+```ini
+*/15 * * * * = General:Current weather: {cmd:wx Seattle}
+```
+
+**Invalid (too frequent):**
+```ini
+*/5 * * * * = General:Weather: {cmd:wx Seattle}
+```
+
+---
+
+## Tips and Best Practices
+
+1. **Use the web UI for initial setup** — it validates your schedule and shows the next 5 run times
+2. **Start with simplified modes** for common patterns, then switch to Advanced/Flexible for complex schedules
+3. **Avoid overly frequent schedules** — remember that every message uses mesh airtime
+4. **Use scoped floods** for regional messages to avoid unnecessary network load
+5. **Use flexible cron for readability** — `4th tue 19:00 jan-oct` is clearer than `0 19 * jan-oct tue` when editing config files
+6. **Use HHMM (no colon) in config.ini** if manually editing flexible cron, to avoid the `!` encoding
+
+---
+
+## Troubleshooting
+
+### My schedule isn't firing
+
+1. Check that the schedule expression is valid using the web UI preview
+2. Verify the timezone setting in `[Bot]` matches your expectation
+3. Look for warnings in the bot logs about invalid schedules
+4. Ensure the message value contains a colon (e.g., `Channel:Message`)
+
+### My flexible cron key has `!` instead of `:`
+
+This is normal for flexible cron entries created through the web UI. The bot automatically converts `!` back to `:` when loading. If manually editing, use `!` in the schedule key or use `HHMM` format without punctuation.
+
+### Schedule works in the UI but not after restarting the bot
+
+The bot reloads schedules when the web viewer saves changes, but you may need to restart the bot if you manually edited `config.ini` while it was running.
+
+### Day-of-week isn't working as expected
+
+Remember that day-of-week uses APScheduler's numbering: 0=Monday, 6=Sunday. This differs from traditional Unix cron (0=Sunday). Use day names (`mon`, `tue`, etc.) to avoid confusion.
+
+---
+
+## Summary Reference
+
+| Format Type | Use When | Example |
+|-------------|----------|---------|
+| **Simplified** | Setting up common patterns via web UI | "Daily at 8:00 AM" |
+| **Standard cron** | You're familiar with cron syntax | `0 8 * * *` |
+| **Flexible cron** | You want readable, order-independent syntax | `4th tue 19:00 jan-oct` |
+| **Presets** | Very simple recurring schedules | `@daily`, `@weekly` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Check-in API: checkin-api.md
     - Path Command: path-command-config.md
     - Config validation: config-validation.md
+    - Scheduled messages: scheduled-messages.md
   - Web Viewer: web-viewer.md
   - Command Reference:
     - Overview: command-reference.md

--- a/modules/scheduled_message_admin.py
+++ b/modules/scheduled_message_admin.py
@@ -17,7 +17,12 @@ import configparser
 import datetime
 from typing import Any
 
-from .scheduled_message_cron import parse_schedule_key, parse_scheduled_message_value
+from .scheduled_message_cron import (
+    decode_schedule_key_from_ini,
+    encode_schedule_key_for_ini,
+    parse_schedule_key,
+    parse_scheduled_message_value,
+)
 
 SECTION = "Scheduled_Messages"
 
@@ -81,9 +86,9 @@ def describe_schedule(
     if parsed.trigger is None:
         return {
             "valid": False,
-            "error": (
+            "error": parsed.error or (
                 "Not a valid schedule. Use 5-field cron (minute hour day-of-month "
-                "month day-of-week), or a preset like @daily or @hourly."
+                "month day-of-week), flexible cron or a preset like @daily or @hourly."
             ),
             "next_runs": [],
         }
@@ -180,7 +185,10 @@ def read_entries(config_path: str, tz: Any) -> list[dict[str, Any]]:
         return []
 
     entries: list[dict[str, Any]] = []
-    for schedule, raw_value in parser.items(SECTION):
+    for raw_schedule, raw_value in parser.items(SECTION):
+        # config.ini stores flexible-cron HH:MM times as HH!MM (":" is the INI
+        # key/value separator); decode back to HH:MM for display/parsing.
+        schedule = decode_schedule_key_from_ini(raw_schedule)
         entry: dict[str, Any] = {
             "schedule": schedule,
             "raw_value": raw_value,

--- a/modules/scheduled_message_admin.py
+++ b/modules/scheduled_message_admin.py
@@ -19,7 +19,6 @@ from typing import Any
 
 from .scheduled_message_cron import (
     decode_schedule_key_from_ini,
-    encode_schedule_key_for_ini,
     parse_schedule_key,
     parse_scheduled_message_value,
 )

--- a/modules/scheduled_message_cron.py
+++ b/modules/scheduled_message_cron.py
@@ -16,7 +16,6 @@ Day-of-week uses APScheduler numbering (0=Monday … 6=Sunday), not Vixie cron
 from __future__ import annotations
 
 import re
-
 from dataclasses import dataclass
 from typing import Optional
 
@@ -138,7 +137,7 @@ def is_valid_legacy_hhmm(time_str: str) -> bool:
 def parse_flexible_cron(time_str: str) -> dict[str, str]:
     """Return a dictionary of CronTrigger parameters by parsing time_str.
     If time_str does not parse as a valid time expression return None."""
-    params = dict();
+    params = dict()
 
     # Is a start date being specified
     match = start_date_re.search(time_str)
@@ -235,7 +234,7 @@ def parse_schedule_key(
     """
     raw = (schedule_key or "").strip()
     if not raw:
-        return ScheduleParseResult(None, "", False, None)
+        return ScheduleParseResult(None, "", False, "")
 
     lowered = raw.lower()
 
@@ -245,7 +244,7 @@ def parse_schedule_key(
         minute = int(raw[2:])
         trigger = CronTrigger(hour=hour, minute=minute, timezone=timezone)
         display = f"{hour:02d}:{minute:02d}"
-        return ScheduleParseResult(trigger, display, True, None)
+        return ScheduleParseResult(trigger, display, True, "")
 
     # 2) @preset aliases
     if lowered in _SPECIAL_PRESET_TO_CRON:
@@ -253,13 +252,13 @@ def parse_schedule_key(
         try:
             trigger = CronTrigger.from_crontab(cron_expr, timezone=timezone)
         except ValueError as e:
-            return ScheduleParseResult(None, raw, False, e)
-        return ScheduleParseResult(trigger, raw, False, None)
+            return ScheduleParseResult(None, raw, False, str(e))
+        return ScheduleParseResult(trigger, raw, False, "")
 
     # 3) Standard 5-field crontab
     if re.match(cron_re, raw):
         trigger = CronTrigger.from_crontab(raw, timezone=timezone)
-        return ScheduleParseResult(trigger, raw, False, None)
+        return ScheduleParseResult(trigger, raw, False, "")
 
     # 4) Flexible crontab
     cron_trigger_kw = parse_flexible_cron(raw)
@@ -268,7 +267,7 @@ def parse_schedule_key(
             return ScheduleParseResult(None, raw, False, cron_trigger_kw['error'])
 
         trigger = CronTrigger(**cron_trigger_kw, timezone=timezone)
-        return ScheduleParseResult(trigger, raw, False, None)
+        return ScheduleParseResult(trigger, raw, False, "")
 
     # Crontab entry not recognized
     return ScheduleParseResult(None, raw, False, "crontab entry not recognized or parsable")

--- a/modules/scheduled_message_cron.py
+++ b/modules/scheduled_message_cron.py
@@ -17,14 +17,15 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import date
 from typing import Optional
 
 from apscheduler.triggers.cron import CronTrigger
 
 dow_names = r'(?:mon|tue|wed|thu|fri|sat|sun)'
 month_names = r'(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)'
-hour_pattern = r'(?:[0-1]?\d|2[0-3]|\*)(?:(?:[\/-](?:[0-1]?\d|2[0-3]))|(?:,(?:[0-1]?\d|2[0-3]))+)?'
-minute_pattern = r'(?:[0-5]?\d|\*)(?:(?:[\/\-][0-5]?\d)|(?:,[0-5]?\d)+)?'
+hour_pattern = r'(?:\d+|\*)(?:[\/-]\d+|(?:,\d+)+)?'
+minute_pattern = r'(?:\d+|\*)(?:[\/\-]\d+|(?:,\d+)+)?'
 day_pattern = r'(?:[0-2]?\d|3[01]|\*)(?:(?:[\/\-](?:[0-2]?\d|3[01]))|(?:,(?:[0-2]?\d|3[01]))+)?'
 month_pattern = fr'(?:[1-9]|1[0-2]|{month_names}|\*)(?:(?:[\/\-,](?:[1-9]|1[0-2]|{month_names}))+)?'
 dow_pattern = fr'(?:[0-6]|{dow_names}|\*)(?:(?:[\/\-,](?:[0-6]|{dow_names}))+)?'
@@ -33,13 +34,13 @@ dow_prefix_pattern = r'(?:(?:1st|2nd|3rd|4th|5th|last))'
 cron_re = re.compile(fr'^{minute_pattern}\s+{hour_pattern}\s+{day_pattern}\s+{month_pattern}\s+{dow_pattern}$', re.I)
 
 # regexs use to parse flexible cron
-hour_re = re.compile(fr'\b{hour_pattern}h\b', re.I)
-minute_re = re.compile(fr'\b{minute_pattern}m\b', re.I)
+hour_re = re.compile(fr'(?:\s?){hour_pattern}h\b', re.I)
+minute_re = re.compile(fr'(?:\s?){minute_pattern}m\b', re.I)
 day_re = re.compile(fr'\b{day_pattern}d\b', re.I)
 month_re = re.compile(fr'\b{month_pattern}\b', re.I)
 dow_re = re.compile(r'\b'+dow_pattern+r'\b', re.I)
 dow_prefix_re = re.compile(fr'\b{dow_prefix_pattern}\b', re.I)
-week_re = re.compile(r'\b(?:\d{1,2}|\*)(?:(?:[\/\-]\d{1,2})|(?:,\d{1,2})+)?w\b', re.I)
+week_re = re.compile(r'(?:\s?)(?:\d{1,2}|\*)(?:(?:[\/\-]\d{1,2})|(?:,\d{1,2})+)?w\b', re.I)
 hhmm_re = re.compile(r'\b(?P<hour>(?:[0-1]\d|2[0-3])):?(?P<min>[0-5]\d)\b')
 start_date_re = re.compile(r'\bstart[:=](?P<date>[\d\-]+)\b')
 end_date_re = re.compile(r'\bend[:=](?P<date>[\d\-]+)\b')
@@ -101,7 +102,7 @@ class ScheduleParseResult:
     is_deprecated_hhmm: bool
     """True when the legacy HHMM daily form was used."""
 
-    error: str
+    error: Optional[str]
     """When trigger is None, error can include reason for invalid trigger."""
 
 
@@ -145,6 +146,9 @@ def parse_flexible_cron(time_str: str) -> dict[str, str]:
         date_match = iso_date_re.search(match.group(0))
         if date_match:
             params['start_date'] = date_match.group(0)
+            if params['start_date'].startswith('0000-'):
+                # insert the current year
+                params['start_date'] = re.sub(r'^0000', str(date.today().year), params['start_date'])
             time_str = start_date_re.sub('', time_str)
         else:
             params['error'] = 'Invalid ISO date (YYYY-MM-DD)'
@@ -155,6 +159,9 @@ def parse_flexible_cron(time_str: str) -> dict[str, str]:
         date_match = iso_date_re.search(match.group(0))
         if date_match:
             params['end_date'] = date_match.group(0)
+            if params['end_date'].startswith('0000-'):
+                # insert the current year
+                params['end_date'] = re.sub(r'^0000', str(date.today().year), params['end_date'])
             time_str = end_date_re.sub('', time_str)
         else:
             params['error'] = 'Invalid ISO date (YYYY-MM-DD)'
@@ -169,18 +176,21 @@ def parse_flexible_cron(time_str: str) -> dict[str, str]:
         # Look for hours
         match = hour_re.search(time_str)
         if match:
-            params['hour'] = match.group(0)[:-1]
+            # [:-1] removes the 'h' from the expression
+            params['hour'] = match.group(0)[:-1].strip()
             time_str = hour_re.sub('', time_str)
 
         # Look for mins
         match = minute_re.search(time_str)
         if match:
-            params['minute'] = match.group(0)[:-1]
+            # [:-1] removes the 'm' from the expression
+            params['minute'] = match.group(0)[:-1].strip()
             time_str = minute_re.sub('', time_str)
 
     # Look for day of month
     match = day_re.search(time_str)
     if match:
+        # [:-1] removes the 'd' form the expression
         params['day'] = match.group(0)[:-1]
         time_str = day_re.sub('', time_str)
 
@@ -214,7 +224,7 @@ def parse_flexible_cron(time_str: str) -> dict[str, str]:
     # If anything left in time_str (other than whitespace) is
     # considered an error condition and return empty dictionary
     if time_str.strip() and 'error' not in params:
-        return dict(error=f'Unparsable component: {time_str}')
+        return dict(error=f'Unparsable component: "{time_str}" parsed: {params=}')
     return params
 
 
@@ -234,7 +244,7 @@ def parse_schedule_key(
     """
     raw = (schedule_key or "").strip()
     if not raw:
-        return ScheduleParseResult(None, "", False, "")
+        return ScheduleParseResult(None, "", False, "No schedule_key specified")
 
     lowered = raw.lower()
 
@@ -244,7 +254,7 @@ def parse_schedule_key(
         minute = int(raw[2:])
         trigger = CronTrigger(hour=hour, minute=minute, timezone=timezone)
         display = f"{hour:02d}:{minute:02d}"
-        return ScheduleParseResult(trigger, display, True, "")
+        return ScheduleParseResult(trigger, display, True, None)
 
     # 2) @preset aliases
     if lowered in _SPECIAL_PRESET_TO_CRON:
@@ -253,12 +263,12 @@ def parse_schedule_key(
             trigger = CronTrigger.from_crontab(cron_expr, timezone=timezone)
         except ValueError as e:
             return ScheduleParseResult(None, raw, False, str(e))
-        return ScheduleParseResult(trigger, raw, False, "")
+        return ScheduleParseResult(trigger, raw, False, None)
 
     # 3) Standard 5-field crontab
     if re.match(cron_re, raw):
         trigger = CronTrigger.from_crontab(raw, timezone=timezone)
-        return ScheduleParseResult(trigger, raw, False, "")
+        return ScheduleParseResult(trigger, raw, False, None)
 
     # 4) Flexible crontab
     cron_trigger_kw = parse_flexible_cron(raw)
@@ -267,7 +277,10 @@ def parse_schedule_key(
             return ScheduleParseResult(None, raw, False, cron_trigger_kw['error'])
 
         trigger = CronTrigger(**cron_trigger_kw, timezone=timezone)
-        return ScheduleParseResult(trigger, raw, False, "")
+        print(f"{trigger=}")
+        if not trigger:
+            return ScheduleParseResult(trigger, raw, False, "Unparsable time specification")
+        return ScheduleParseResult(trigger, raw, False, None)
 
     # Crontab entry not recognized
     return ScheduleParseResult(None, raw, False, "crontab entry not recognized or parsable")

--- a/modules/scheduled_message_cron.py
+++ b/modules/scheduled_message_cron.py
@@ -15,11 +15,36 @@ Day-of-week uses APScheduler numbering (0=Monday … 6=Sunday), not Vixie cron
 
 from __future__ import annotations
 
+import re
+
 from dataclasses import dataclass
 from typing import Optional
 
 from apscheduler.triggers.cron import CronTrigger
 
+dow_names = r'(?:mon|tue|wed|thu|fri|sat|sun)'
+month_names = r'(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)'
+hour_pattern = r'(?:[0-1]?\d|2[0-3]|\*)(?:(?:[\/-](?:[0-1]?\d|2[0-3]))|(?:,(?:[0-1]?\d|2[0-3]))+)?'
+minute_pattern = r'(?:[0-5]?\d|\*)(?:(?:[\/\-][0-5]?\d)|(?:,[0-5]?\d)+)?'
+day_pattern = r'(?:[0-2]?\d|3[01]|\*)(?:(?:[\/\-](?:[0-2]?\d|3[01]))|(?:,(?:[0-2]?\d|3[01]))+)?'
+month_pattern = fr'(?:[1-9]|1[0-2]|{month_names}|\*)(?:(?:[\/\-,](?:[1-9]|1[0-2]|{month_names}))+)?'
+dow_pattern = fr'(?:[0-6]|{dow_names}|\*)(?:(?:[\/\-,](?:[0-6]|{dow_names}))+)?'
+dow_prefix_pattern = r'(?:(?:1st|2nd|3rd|4th|5th|last))'
+
+cron_re = re.compile(fr'^{minute_pattern}\s+{hour_pattern}\s+{day_pattern}\s+{month_pattern}\s+{dow_pattern}$', re.I)
+
+# regexs use to parse flexible cron
+hour_re = re.compile(fr'\b{hour_pattern}h\b', re.I)
+minute_re = re.compile(fr'\b{minute_pattern}m\b', re.I)
+day_re = re.compile(fr'\b{day_pattern}d\b', re.I)
+month_re = re.compile(fr'\b{month_pattern}\b', re.I)
+dow_re = re.compile(r'\b'+dow_pattern+r'\b', re.I)
+dow_prefix_re = re.compile(fr'\b{dow_prefix_pattern}\b', re.I)
+week_re = re.compile(r'\b(?:\d{1,2}|\*)(?:(?:[\/\-]\d{1,2})|(?:,\d{1,2})+)?w\b', re.I)
+hhmm_re = re.compile(r'\b(?P<hour>(?:[0-1]\d|2[0-3])):?(?P<min>[0-5]\d)\b')
+start_date_re = re.compile(r'\bstart:(?P<date>[\d\-]+)\b')
+end_date_re = re.compile(r'\bend:(?P<date>[\d\-]+)\b')
+iso_date_re = re.compile(r'\d{4}-\d{1,2}-\d{1,2}')
 
 def parse_scheduled_message_value(raw: str) -> tuple[str, str, str | None]:
     """Parse a ``[Scheduled_Messages]`` option value into ``(channel, message, scope)``.
@@ -77,6 +102,26 @@ class ScheduleParseResult:
     is_deprecated_hhmm: bool
     """True when the legacy HHMM daily form was used."""
 
+    error: str
+    """When trigger is None, error can include reason for invalid trigger."""
+
+
+def encode_schedule_key_for_ini(schedule_key: str) -> str:
+    """Make a schedule key safe to store as an INI key.
+
+    The line-based INI writer/reader (and ``configparser`` itself) treat ``:``
+    (and ``=``) as the key/value separator, so a flexible-cron key containing an
+    HH:MM time — e.g. ``4th tue 14:00 jan-oct`` — would corrupt the line. ``!``
+    never appears in a valid schedule key, so it round-trips losslessly with
+    :func:`decode_schedule_key_from_ini`.
+    """
+    return (schedule_key or "").replace(":", "!")
+
+
+def decode_schedule_key_from_ini(schedule_key: str) -> str:
+    """Inverse of :func:`encode_schedule_key_for_ini`."""
+    return (schedule_key or "").replace("!", ":")
+
 
 def is_valid_legacy_hhmm(time_str: str) -> bool:
     """Return True if ``time_str`` is a valid legacy HHMM clock time (24h)."""
@@ -88,6 +133,90 @@ def is_valid_legacy_hhmm(time_str: str) -> bool:
         return 0 <= hour <= 23 and 0 <= minute <= 59
     except ValueError:
         return False
+
+
+def parse_flexible_cron(time_str: str) -> dict[str, str]:
+    """Return a dictionary of CronTrigger parameters by parsing time_str.
+    If time_str does not parse as a valid time expression return None."""
+    params = dict();
+
+    # Is a start date being specified
+    match = start_date_re.search(time_str)
+    if match:
+        date_match = iso_date_re.search(match.group(0))
+        if date_match:
+            params['start_date'] = date_match.group(0)
+            time_str = start_date_re.sub('', time_str)
+        else:
+            params['error'] = 'Invalid ISO date (YYYY-MM-DD)'
+
+    # Is an end date being specified
+    match = end_date_re.search(time_str)
+    if match:
+        date_match = iso_date_re.search(match.group(0))
+        if date_match:
+            params['end_date'] = date_match.group(0)
+            time_str = end_date_re.sub('', time_str)
+        else:
+            params['error'] = 'Invalid ISO date (YYYY-MM-DD)'
+
+    # Look for HH:MM or HHMM specification
+    match = hhmm_re.search(time_str)
+    if match:
+        params['hour'] = match.group('hour')
+        params['minute'] = match.group('min')
+        time_str = hhmm_re.sub('', time_str)
+    else:
+        # Look for hours
+        match = hour_re.search(time_str)
+        if match:
+            params['hour'] = match.group(0)[:-1]
+            time_str = hour_re.sub('', time_str)
+
+        # Look for mins
+        match = minute_re.search(time_str)
+        if match:
+            params['minute'] = match.group(0)[:-1]
+            time_str = minute_re.sub('', time_str)
+
+    # Look for day of month
+    match = day_re.search(time_str)
+    if match:
+        params['day'] = match.group(0)[:-1]
+        time_str = day_re.sub('', time_str)
+
+    # Look for month
+    match = month_re.search(time_str)
+    if match:
+        params['month'] = match.group(0)
+        time_str = month_re.sub('', time_str)
+
+    # Look for week
+    match = week_re.search(time_str)
+    if match:
+        params['week'] = match.group(0)[:-1]
+        time_str = week_re.sub('', time_str)
+
+    # Look for day of week
+    prefix_match = dow_prefix_re.search(time_str)
+    dow_match = dow_re.search(time_str)
+    if prefix_match and dow_match:
+        params['day'] = f"{prefix_match.group(0)} {dow_match.group(0)}"
+        time_str = dow_prefix_re.sub('', time_str)
+        time_str = dow_re.sub('', time_str)
+    elif prefix_match and prefix_match.group(0).lower() == 'last':
+        # special case: last day of the month
+        params['day'] = 'last'
+        time_str = dow_prefix_re.sub('', time_str)
+    elif dow_match:
+        params['day_of_week'] = dow_match.group(0)
+        time_str = dow_re.sub('', time_str)
+
+    # If anything left in time_str (other than whitespace) is
+    # considered an error condition and return empty dictionary
+    if time_str.strip() and 'error' not in params:
+        return dict(error=f'Unparsable component: {time_str}')
+    return params
 
 
 def parse_schedule_key(
@@ -106,7 +235,7 @@ def parse_schedule_key(
     """
     raw = (schedule_key or "").strip()
     if not raw:
-        return ScheduleParseResult(None, "", False)
+        return ScheduleParseResult(None, "", False, None)
 
     lowered = raw.lower()
 
@@ -116,20 +245,30 @@ def parse_schedule_key(
         minute = int(raw[2:])
         trigger = CronTrigger(hour=hour, minute=minute, timezone=timezone)
         display = f"{hour:02d}:{minute:02d}"
-        return ScheduleParseResult(trigger, display, True)
+        return ScheduleParseResult(trigger, display, True, None)
 
     # 2) @preset aliases
     if lowered in _SPECIAL_PRESET_TO_CRON:
         cron_expr = _SPECIAL_PRESET_TO_CRON[lowered]
         try:
             trigger = CronTrigger.from_crontab(cron_expr, timezone=timezone)
-        except ValueError:
-            return ScheduleParseResult(None, raw, False)
-        return ScheduleParseResult(trigger, raw, False)
+        except ValueError as e:
+            return ScheduleParseResult(None, raw, False, e)
+        return ScheduleParseResult(trigger, raw, False, None)
 
     # 3) Standard 5-field crontab
-    try:
+    if re.match(cron_re, raw):
         trigger = CronTrigger.from_crontab(raw, timezone=timezone)
-    except ValueError:
-        return ScheduleParseResult(None, raw, False)
-    return ScheduleParseResult(trigger, raw, False)
+        return ScheduleParseResult(trigger, raw, False, None)
+
+    # 4) Flexible crontab
+    cron_trigger_kw = parse_flexible_cron(raw)
+    if cron_trigger_kw:
+        if 'error' in cron_trigger_kw:
+            return ScheduleParseResult(None, raw, False, cron_trigger_kw['error'])
+
+        trigger = CronTrigger(**cron_trigger_kw, timezone=timezone)
+        return ScheduleParseResult(trigger, raw, False, None)
+
+    # Crontab entry not recognized
+    return ScheduleParseResult(None, raw, False, "crontab entry not recognized or parsable")

--- a/modules/scheduled_message_cron.py
+++ b/modules/scheduled_message_cron.py
@@ -41,8 +41,8 @@ dow_re = re.compile(r'\b'+dow_pattern+r'\b', re.I)
 dow_prefix_re = re.compile(fr'\b{dow_prefix_pattern}\b', re.I)
 week_re = re.compile(r'\b(?:\d{1,2}|\*)(?:(?:[\/\-]\d{1,2})|(?:,\d{1,2})+)?w\b', re.I)
 hhmm_re = re.compile(r'\b(?P<hour>(?:[0-1]\d|2[0-3])):?(?P<min>[0-5]\d)\b')
-start_date_re = re.compile(r'\bstart:(?P<date>[\d\-]+)\b')
-end_date_re = re.compile(r'\bend:(?P<date>[\d\-]+)\b')
+start_date_re = re.compile(r'\bstart[:=](?P<date>[\d\-]+)\b')
+end_date_re = re.compile(r'\bend[:=](?P<date>[\d\-]+)\b')
 iso_date_re = re.compile(r'\d{4}-\d{1,2}-\d{1,2}')
 
 def parse_scheduled_message_value(raw: str) -> tuple[str, str, str | None]:

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -25,6 +25,7 @@ from meshcore.events import EventType
 from .maintenance import MaintenanceRunner
 from .models import CHANNEL_REGIONAL_FLOOD_SCOPE_BODY_OVERHEAD
 from .scheduled_message_cron import (
+    decode_schedule_key_from_ini,
     is_valid_legacy_hhmm,
     parse_schedule_key,
     parse_scheduled_message_value,
@@ -113,7 +114,10 @@ class MessageScheduler:
 
         if self.bot.config.has_section('Scheduled_Messages'):
             self.logger.info("Found Scheduled_Messages section")
-            for schedule_key, message_info in self.bot.config.items('Scheduled_Messages'):
+            for raw_schedule_key, message_info in self.bot.config.items('Scheduled_Messages'):
+                # config.ini stores flexible-cron HH:MM times as HH!MM (":" is the
+                # INI key/value separator); decode back to HH:MM before parsing.
+                schedule_key = decode_schedule_key_from_ini(raw_schedule_key)
                 self.logger.info(f"Processing scheduled message: '{schedule_key}' -> '{message_info}'")
                 try:
                     parsed = parse_schedule_key(schedule_key, tz)

--- a/modules/web_viewer/app.py
+++ b/modules/web_viewer/app.py
@@ -63,6 +63,7 @@ from modules.scheduled_message_admin import (
     read_entries,
     validate_entry,
 )
+from modules.scheduled_message_cron import encode_schedule_key_for_ini
 from modules.security_utils import (
     SafeUrlPolicy,
     create_safe_requests_session,
@@ -4070,10 +4071,17 @@ class BotDataViewer:
                     ),
                 }), 409
 
-            updates = {SCHEDULED_MESSAGES_SECTION: {schedule: compose_value(channel, message, scope)}}
+            # config.ini uses ":" as the key/value separator, so a flexible-cron
+            # key containing HH:MM (e.g. "4th tue 14:00 jan-oct") must be encoded
+            # as HH!MM to survive the round-trip; read_entries() decodes it back.
+            updates = {
+                SCHEDULED_MESSAGES_SECTION: {
+                    encode_schedule_key_for_ini(schedule): compose_value(channel, message, scope)
+                }
+            }
             deletes = None
             if replacing and replacing != schedule:
-                deletes = {SCHEDULED_MESSAGES_SECTION: [replacing]}
+                deletes = {SCHEDULED_MESSAGES_SECTION: [encode_schedule_key_for_ini(replacing)]}
 
             try:
                 summary = update_ini_values(self.config_path, updates, deletes)
@@ -4152,7 +4160,9 @@ class BotDataViewer:
                         }), 404
                     try:
                         update_ini_values(
-                            self.config_path, {}, {SCHEDULED_MESSAGES_SECTION: [schedule]}
+                            self.config_path,
+                            {},
+                            {SCHEDULED_MESSAGES_SECTION: [encode_schedule_key_for_ini(schedule)]},
                         )
                     except OSError as exc:
                         self.logger.error("Failed to delete scheduled message: %s", exc)

--- a/modules/web_viewer/templates/schedule.html
+++ b/modules/web_viewer/templates/schedule.html
@@ -65,6 +65,7 @@
                         <option value="interval_hours">Every N hours</option>
                         <option value="interval_minutes">Every N minutes</option>
                         <option value="advanced">Advanced (cron)</option>
+                        <option value="flexible">Flexible (cron)</option>
                     </select>
                 </div>
 
@@ -99,8 +100,23 @@
                                placeholder="0 6,12,18 * * *">
                         <div class="form-text">
                             Five fields: minute hour day-of-month month day-of-week.
-                            Day-of-week is 0=Monday here, not Sunday. Presets like
+                            Day-of-week is 0=Monday here, not Sunday. 3 letter
+                            month and day-of-week can be used. Presets like
                             <code>@daily</code> and <code>@hourly</code> also work.
+                        </div>
+                    </div>
+                    <div class="col-12 d-none" id="fieldFlexible">
+                        <label class="form-label" for="scheduleFlexible">Flexible cron expression</label>
+                        <input type="text" class="form-control font-monospace" id="scheduleFlexible"
+                               placeholder="2nd wed mar-jul 14:30">
+                        <div class="form-text">
+                            Fields can come in any order. Time may be specified
+                            as HH:MM, HHMM, ##h ##m. Months must be 3 character
+                            labels (i.e feb) and day of month must be ##d. Week
+                            can be specified as ##w. Day of week must be 3 character
+                            label (i.e. wed) and can be qualified by 1st, 2nd,
+                            3rd, 4th, 5th or last. Any field not specified
+                            defaults to '*'.
                         </div>
                     </div>
                 </div>
@@ -210,6 +226,7 @@
     function composeCron() {
         const mode = $('scheduleMode').value;
         if (mode === 'advanced') return $('scheduleCron').value.trim();
+        if (mode === 'flexible') return $('scheduleFlexible').value.trim();
 
         if (mode === 'interval_minutes') {
             const n = parseInt($('scheduleEveryMinutes').value, 10);
@@ -245,6 +262,7 @@
         show('fieldEveryMinutes', mode === 'interval_minutes');
         show('fieldDays', mode === 'weekly');
         show('fieldCron', mode === 'advanced');
+        show('fieldFlexible', mode === "flexible");
         schedulePreview();
     }
 
@@ -289,8 +307,21 @@
         $('scheduleMessage').value = entry ? entry.message : '';
         // Existing entries open in Advanced so the stored cron is never silently
         // rewritten into something the friendly controls happen to produce.
-        $('scheduleMode').value = entry ? 'advanced' : 'daily';
-        $('scheduleCron').value = entry ? entry.schedule : '';
+        if (entry) {
+            const cron_regex = /^(?:[\d\-,\/\*]+\s+){3}([\d\-,\/a-z\*]+)\s+([\d\-,\/a-z\*]+)$/i;
+            if (cron_regex.test(entry.schedule)) {
+                $('scheduleMode').value = 'advanced';
+                $('scheduleCron').value = entry.schedule;
+            } else {
+                $('scheduleMode').value = 'flexible';
+                $('scheduleFlexible').value = entry.schedule;
+            }
+        } else {
+            $('scheduleMode').value = 'daily';
+            $('scheduleCron').value = '';
+        }
+
+
         syncModeFields();
         modal.show();
     }
@@ -403,7 +434,7 @@
         $('saveScheduleBtn').addEventListener('click', save);
         $('scheduleMode').addEventListener('change', syncModeFields);
         ['scheduleTime', 'scheduleTimes', 'scheduleEveryHours', 'scheduleEveryMinutes',
-         'scheduleCron', 'scheduleMessage'].forEach((id) =>
+         'scheduleCron', 'scheduleFlexible', 'scheduleMessage'].forEach((id) =>
             $(id).addEventListener('input', schedulePreview));
         syncModeFields();
         load();

--- a/tests/test_scheduler_logic.py
+++ b/tests/test_scheduler_logic.py
@@ -213,6 +213,26 @@ class TestSetupScheduledMessages:
         assert len(self._message_jobs(scheduler)) == 1
         self._teardown(scheduler)
 
+    def test_flexible_cron_key_with_encoded_time_is_decoded_and_registered(self, scheduler):
+        """config.ini stores flexible-cron HH:MM as HH!MM (":" is the INI
+        key/value separator); setup_scheduled_messages() must decode it back
+        before parsing, or the entry silently fails to schedule."""
+        scheduler.bot.config.add_section("Scheduled_Messages")
+        scheduler.bot.config.set(
+            "Scheduled_Messages",
+            "4th tue 14!00 jan-oct",
+            "Volusia ARES:ARES meeting tonight",
+        )
+        self._setup_and_call(scheduler)
+        assert "4th tue 14:00 jan-oct" in scheduler.scheduled_messages
+        channel, message, label, scope = scheduler.scheduled_messages["4th tue 14:00 jan-oct"]
+        assert scope is None
+        assert channel == "Volusia ARES"
+        assert "ARES meeting tonight" in message
+        assert label == "4th tue 14:00 jan-oct"
+        assert len(self._message_jobs(scheduler)) == 1
+        self._teardown(scheduler)
+
     def test_invalid_cron_skipped(self, scheduler):
         scheduler.bot.config.add_section("Scheduled_Messages")
         scheduler.bot.config.set(

--- a/tests/unit/test_scheduled_message_admin.py
+++ b/tests/unit/test_scheduled_message_admin.py
@@ -27,7 +27,8 @@ class TestDescribeSchedule:
                                       "0 8 15 oct-dec *", "0 8 * jun,jul,sep *", "0 8 * jan,mar wed",
                                       "0 8 * may-oct,dec *", "0 8 * * mon-wed,sat,sun",
                                       "1st tue 10:00", "last sat 9h */15m", "mon jun-jul 0815",
-                                      "5,15,25d 15m", "feb 10-20d 23:30", "3w 7-15h 45m"])
+                                      "5,15,25d 15m", "feb 10-20d 23:30", "3w 7-15h 45m",
+                                      "*/30m thu", "*/4h", "mon-fri */6h", "jan *h", "*h"])
     def test_accepts_valid_schedules(self, cron):
         assert describe_schedule(cron, TZ)["valid"] is True
 

--- a/tests/unit/test_scheduled_message_admin.py
+++ b/tests/unit/test_scheduled_message_admin.py
@@ -22,11 +22,24 @@ TZ = datetime.timezone.utc
 
 @pytest.mark.unit
 class TestDescribeSchedule:
-    @pytest.mark.parametrize("cron", ["0 8 * * *", "0 6,12,18 * * *", "*/30 * * * *", "@daily"])
+    @pytest.mark.parametrize("cron", ["0 8 * * *", "0 6,12,18 * * *", "*/30 * * * *", "@daily",
+                                      "0 8 * * sun", "0 8 * * mon,wed,fri", "0 8 15 jan *",
+                                      "0 8 15 oct-dec *", "0 8 * jun,jul,sep *", "0 8 * jan,mar wed",
+                                      "0 8 * may-oct,dec *", "0 8 * * mon-wed,sat,sun",
+                                      "1st tue 10:00", "last sat 9h */15m", "mon jun-jul 0815",
+                                      "5,15,25d 15m", "feb 10-20d 23:30", "3w 7-15h 45m"])
     def test_accepts_valid_schedules(self, cron):
         assert describe_schedule(cron, TZ)["valid"] is True
 
-    @pytest.mark.parametrize("bad", ["", "   ", "nonsense", "0 8 * *", "99 99 * * *"])
+    @pytest.mark.parametrize("Cron", ["0 8 * * SUN", "0 8 * * Mon,Wed", "0 8 15 JAN *",
+                                          "0 8 15 Oct-Dec *", "0 8 * jUn,jUl,sEp *",
+                                          "1ST Tue 10:00", "lASt sAt 9h */15m", "mon jun-jul 0815",
+                                          "5,15,25D 15M", "FEB 10-20d 23:30", "3W 7-15H 45M"])
+    def test_accepts_valid_case_insensitive_schedules(self, Cron):
+        assert describe_schedule(Cron, TZ)["valid"] is True
+
+    @pytest.mark.parametrize("bad", ["", "   ", "nonsense", "0 8 * *", "99 99 * * *",
+                                     "0 8 * tue *", "0 8 * * jan"])
     def test_rejects_invalid_schedules(self, bad):
         result = describe_schedule(bad, TZ)
         assert result["valid"] is False
@@ -49,7 +62,6 @@ class TestDescribeSchedule:
         assert result["valid"] is True
         assert result["deprecated"] is True
         assert "deprecated" in result["warning"].lower()
-
 
 @pytest.mark.unit
 class TestCommandPlaceholderFloor:

--- a/tests/unit/test_scheduled_message_cron.py
+++ b/tests/unit/test_scheduled_message_cron.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the scheduled-message cron helpers.
+"""
+
+import datetime
+import re
+
+import pytest
+
+from modules.scheduled_message_cron import (
+    encode_schedule_key_for_ini,
+    decode_schedule_key_from_ini,
+    is_valid_legacy_hhmm,
+    parse_flexible_cron,
+    parse_schedule_key,
+)
+
+TZ = datetime.timezone.utc
+
+
+@pytest.mark.unit
+class TestEncodeDecodeScheduleKey:
+    def test_encode_replaces_colon_with_bang(self):
+        assert encode_schedule_key_for_ini("4th tue 14:00 jan-oct") == "4th tue 14!00 jan-oct"
+
+    def test_decode_replaces_bang_with_colon(self):
+        assert decode_schedule_key_from_ini("4th tue 14!00 jan-oct") == "4th tue 14:00 jan-oct"
+
+    def test_encode_does_nothing_without_a_colon(self):
+        assert encode_schedule_key_for_ini("0 8 * * *") == "0 8 * * *"
+
+    def test_decode_does_nothing_without_a_bang(self):
+        assert decode_schedule_key_from_ini("0 8 * * *") == "0 8 * * *"
+
+    def test_encode_handles_none_and_empty(self):
+        assert encode_schedule_key_for_ini("") == ""
+        assert encode_schedule_key_for_ini(None) == ""
+
+    def test_decode_handles_none_and_empty(self):
+        assert decode_schedule_key_from_ini("") == ""
+        assert decode_schedule_key_from_ini(None) == ""
+
+    @pytest.mark.parametrize("key", [
+        "4th tue 14:00 jan-oct",
+        "1st mon 09:05",
+        "last fri 23:59 dec",
+        "0 8 * * *",
+        "@daily",
+    ])
+    def test_round_trips(self, key):
+        assert decode_schedule_key_from_ini(encode_schedule_key_for_ini(key)) == key
+
+
+@pytest.mark.unit
+class TestIsValidLegacyHhmm:
+    @pytest.mark.parametrize("value", ["0000", "0800", "1234", "2359"])
+    def test_accepts_valid_hhmm(self, value):
+        assert is_valid_legacy_hhmm(value) is True
+
+    @pytest.mark.parametrize("value", [
+        "", "800", "080", "24:00", "2400", "9999", "abcd", "08:00", "  0800", "08 0",
+    ])
+    def test_rejects_invalid_hhmm(self, value):
+        assert is_valid_legacy_hhmm(value) is False
+
+
+@pytest.mark.unit
+class TestParseFlexibleCron:
+    def test_parses_hhmm_with_colon(self):
+        assert parse_flexible_cron("14:30") == {"hour": "14", "minute": "30"}
+
+    def test_parses_hhmm_without_colon(self):
+        assert parse_flexible_cron("1430") == {"hour": "14", "minute": "30"}
+
+    @pytest.mark.parametrize("case", [("9h 45m", {"hour": "9", "minute": "45"}),
+                                      ("9h", {"hour": "9"}),
+                                      ("30m", {"minute": "30"}),
+                                      ("13,14h", {"hour": "13,14"}),
+                                      ("2-6h", {"hour": "2-6"}),
+                                      ("15,45m", {"minute": "15,45"}),
+                                      ("20-40m", {"minute": "20-40"}),
+                                      ("10M 12H", {"hour": "12", "minute": "10"})])
+    def test_parses_hour_and_minute_suffix_forms(self, case):
+        assert parse_flexible_cron(case[0]) == case[1]
+
+    @pytest.mark.parametrize("spec", ["34h", "75m", "12,30h", "2-25h", "15,61m", "0-100m"])
+    def test_invalid_hour_and_minute_suffix_forms(self, spec):
+        assert parse_flexible_cron(spec)["error"].startswith("Unparsable component: ")
+
+    @pytest.mark.parametrize("mon", ["jan", "feb", "mar", "apr", "may", "jun",
+                                     "jul", "aug", "sep", "oct", "nov", "dec",
+                                     "1", "2", "3", "4", "5", "6",
+                                     "7", "8", "9", "10", "11", "12"])
+    def test_parses_bare_month(self, mon):
+        assert parse_flexible_cron(mon) == {"month": mon}
+
+    def test_parses_month_range(self):
+        assert parse_flexible_cron("mar-jul") == {"month": "mar-jul"}
+
+    def test_parses_month_multiple(self):
+        assert parse_flexible_cron("jan,apr,jul,oct") == {"month": "jan,apr,jul,oct"}
+
+    @pytest.mark.parametrize("mon", ["march", "april", "june", "july", "13"])
+    def test_invalid_month(self, mon):
+        assert parse_flexible_cron(mon) == {"error": f"Unparsable component: {mon}"}
+
+    @pytest.mark.parametrize("day", ["15d", "10-15d", "5,15,25d"])
+    def test_parses_day_of_month(self, day):
+        assert parse_flexible_cron(day) == {"day": day[:-1]}
+
+    def test_parses_week(self):
+        assert parse_flexible_cron("3w") == {"week": "3"}
+
+    @pytest.mark.parametrize("dow", ["mon", "tue", "wed", "thu", "fri", "sat", "sun",
+                                     "mon,wed,fri", "mon,wed,fri", ])
+    def test_parses_day_of_week(self, dow):
+        assert parse_flexible_cron(dow) == {"day_of_week": dow}
+
+    @pytest.mark.parametrize("dow", ["tues", "thur"])
+    def test_invalid_day_of_week(self, dow):
+        assert parse_flexible_cron(dow) == {"error": f"Unparsable component: {dow}"}
+
+    @pytest.mark.parametrize("dow", ["1st mon", "2nd tue", "3rd wed", "4th thu",
+                                     "5th fri", "last sat"])
+    def test_parses_day_of_week_with_ordinal_prefix(self, dow):
+        assert parse_flexible_cron(dow) == {"day": dow}
+
+    @pytest.mark.parametrize("dow", ["1st  mon", "2nd     tue"])
+    def test_parses_day_of_week_with_ordinal_prefix_and_extra_spaces(self, dow):
+        assert parse_flexible_cron(dow) == {"day": " ".join(dow.split())}
+
+    def test_parses_last_alone_as_last_day_of_month(self):
+        assert parse_flexible_cron("last") == {"day": "last"}
+
+    def test_combines_multiple_fields(self):
+        assert parse_flexible_cron("4th tue 14:00 jan-oct") == {
+            "hour": "14",
+            "minute": "00",
+            "month": "jan-oct",
+            "day": "4th tue",
+        }
+
+    def test_combines_suffix_time_with_day(self):
+        assert parse_flexible_cron("5,15,25d 15m") == {
+            "minute": "15",
+            "day": "5,15,25"
+        }
+
+    def test_is_case_insensitive(self):
+        assert parse_flexible_cron("4TH TUE 14:00 JAN-OCT") == {
+            "hour": "14",
+            "minute": "00",
+            "month": "JAN-OCT",
+            "day": "4TH TUE",
+        }
+
+    def test_start_date_detected(self):
+        assert parse_flexible_cron("start:2027-01-01") == {
+            "start_date": "2027-01-01"
+        }
+
+    def test_start_date_detected(self):
+        assert parse_flexible_cron("end:2027-01-01") == {
+            "end_date": "2027-01-01"
+        }
+
+    def test_empty_string_returns_empty_dict(self):
+        assert parse_flexible_cron("") == {}
+
+    def test_unrecognized_text_returns_error_attribute(self):
+        assert parse_flexible_cron("nonsense") == {
+            "error": "Unparsable component: nonsense"
+        }
+
+
+@pytest.mark.unit
+class TestParseScheduleKey:
+    def test_empty_key_returns_no_trigger(self):
+        result = parse_schedule_key("", TZ)
+        assert result.trigger is None
+        assert result.display_label == ""
+        assert result.is_deprecated_hhmm is False
+        assert result.error is None
+
+    def test_legacy_hhmm_is_flagged_deprecated(self):
+        result = parse_schedule_key("0800", TZ)
+        assert result.trigger is not None
+        assert result.display_label == "08:00"
+        assert result.is_deprecated_hhmm is True
+        assert result.error is None
+
+    @pytest.mark.parametrize("preset", [
+        "@yearly", "@annually", "@monthly", "@weekly", "@daily", "@midnight", "@hourly",
+    ])
+    def test_preset_aliases_resolve(self, preset):
+        result = parse_schedule_key(preset, TZ)
+        assert result.trigger is not None
+        assert result.is_deprecated_hhmm is False
+        assert result.error is None
+
+    def test_standard_five_field_crontab(self):
+        result = parse_schedule_key("0 8 * * *", TZ)
+        assert result.trigger is not None
+        assert result.is_deprecated_hhmm is False
+        assert result.error is None
+
+    def test_flexible_cron_with_colon_time(self):
+        result = parse_schedule_key("4th tue 14:00 jan-oct", TZ)
+        assert result.trigger is not None
+        assert result.is_deprecated_hhmm is False
+        assert result.error is None
+
+    def test_flexible_cron_encoded_key_is_not_directly_parsed(self):
+        # The caller is responsible for decoding "!" back to ":" before calling
+        # this; an encoded key on its own does not parse as a valid time.
+        result = parse_schedule_key("4th tue 14!00 jan-oct", TZ)
+        assert result.trigger is None
+        assert re.match(r'Unparsable component:\s+14!00', result.error.strip())
+
+    def test_unrecognized_text_returns_no_trigger(self):
+        result = parse_schedule_key("nonsense", TZ)
+        assert result.trigger is None
+        assert result.display_label == "nonsense"
+        assert result.error == "Unparsable component: nonsense"
+
+    def test_whitespace_only_returns_no_trigger(self):
+        result = parse_schedule_key("   ", TZ)
+        assert result.trigger is None
+        assert result.error is None

--- a/tests/unit/test_scheduled_message_cron.py
+++ b/tests/unit/test_scheduled_message_cron.py
@@ -3,8 +3,8 @@
 Unit tests for the scheduled-message cron helpers.
 """
 
-import datetime
 import re
+from datetime import date, timezone
 
 import pytest
 
@@ -16,7 +16,7 @@ from modules.scheduled_message_cron import (
     parse_schedule_key,
 )
 
-TZ = datetime.timezone.utc
+TZ = timezone.utc
 
 
 @pytest.mark.unit
@@ -84,10 +84,6 @@ class TestParseFlexibleCron:
     def test_parses_hour_and_minute_suffix_forms(self, case):
         assert parse_flexible_cron(case[0]) == case[1]
 
-    @pytest.mark.parametrize("spec", ["34h", "75m", "12,30h", "2-25h", "15,61m", "0-100m"])
-    def test_invalid_hour_and_minute_suffix_forms(self, spec):
-        assert parse_flexible_cron(spec)["error"].startswith("Unparsable component: ")
-
     @pytest.mark.parametrize("mon", ["jan", "feb", "mar", "apr", "may", "jun",
                                      "jul", "aug", "sep", "oct", "nov", "dec",
                                      "1", "2", "3", "4", "5", "6",
@@ -103,7 +99,8 @@ class TestParseFlexibleCron:
 
     @pytest.mark.parametrize("mon", ["march", "april", "june", "july", "13"])
     def test_invalid_month(self, mon):
-        assert parse_flexible_cron(mon) == {"error": f"Unparsable component: {mon}"}
+        result = parse_flexible_cron(mon)
+        assert re.match(fr'^Unparsable component: "{mon}"', result["error"])
 
     @pytest.mark.parametrize("day", ["15d", "10-15d", "5,15,25d"])
     def test_parses_day_of_month(self, day):
@@ -119,7 +116,8 @@ class TestParseFlexibleCron:
 
     @pytest.mark.parametrize("dow", ["tues", "thur"])
     def test_invalid_day_of_week(self, dow):
-        assert parse_flexible_cron(dow) == {"error": f"Unparsable component: {dow}"}
+        result = parse_flexible_cron(dow)
+        assert re.match(fr'^Unparsable component: "{dow}"', result["error"])
 
     @pytest.mark.parametrize("dow", ["1st mon", "2nd tue", "3rd wed", "4th thu",
                                      "5th fri", "last sat"])
@@ -160,18 +158,30 @@ class TestParseFlexibleCron:
             "start_date": "2027-01-01"
         }
 
+    def test_start_date_detected_for_current_year(self):
+        current_year = date.today().year
+        assert parse_flexible_cron("start:0000-01-01") == {
+            "start_date": f"{current_year}-01-01"
+        }
+
     def test_end_date_detected(self):
         assert parse_flexible_cron("end:2027-01-01") == {
             "end_date": "2027-01-01"
+        }
+
+    def test_end_date_detected_for_current_year(self):
+        current_year = date.today().year
+        assert parse_flexible_cron("end:0000-01-01") == {
+            "end_date": f"{current_year}-01-01"
         }
 
     def test_empty_string_returns_empty_dict(self):
         assert parse_flexible_cron("") == {}
 
     def test_unrecognized_text_returns_error_attribute(self):
-        assert parse_flexible_cron("nonsense") == {
-            "error": "Unparsable component: nonsense"
-        }
+        result = parse_flexible_cron("nonsense")
+        assert re.match(r'^Unparsable component: "nonsense"', result["error"])
+
 
 
 @pytest.mark.unit
@@ -181,7 +191,7 @@ class TestParseScheduleKey:
         assert result.trigger is None
         assert result.display_label == ""
         assert result.is_deprecated_hhmm is False
-        assert result.error is None
+        assert result.error == "No schedule_key specified"
 
     def test_legacy_hhmm_is_flagged_deprecated(self):
         result = parse_schedule_key("0800", TZ)
@@ -216,15 +226,20 @@ class TestParseScheduleKey:
         # this; an encoded key on its own does not parse as a valid time.
         result = parse_schedule_key("4th tue 14!00 jan-oct", TZ)
         assert result.trigger is None
-        assert re.match(r'Unparsable component:\s+14!00', result.error.strip())
+        assert re.match(r'^Unparsable component: "\s*14!00\s*"', result.error)
 
     def test_unrecognized_text_returns_no_trigger(self):
         result = parse_schedule_key("nonsense", TZ)
         assert result.trigger is None
         assert result.display_label == "nonsense"
-        assert result.error == "Unparsable component: nonsense"
+        assert re.match(r'^Unparsable component: "nonsense"', result.error)
 
     def test_whitespace_only_returns_no_trigger(self):
         result = parse_schedule_key("   ", TZ)
         assert result.trigger is None
-        assert result.error is None
+        assert result.error == "No schedule_key specified"
+
+    @pytest.mark.parametrize("spec", ["34h", "75m", "12,30h", "2-25h", "15,61m", "0-69m", "0-200m"])
+    def test_invalid_hour_and_minute_suffix_forms(self, spec):
+        with pytest.raises(ValueError, match=r"^Error validating expression"):
+            parse_schedule_key(spec, TZ)

--- a/tests/unit/test_scheduled_message_cron.py
+++ b/tests/unit/test_scheduled_message_cron.py
@@ -9,8 +9,8 @@ import re
 import pytest
 
 from modules.scheduled_message_cron import (
-    encode_schedule_key_for_ini,
     decode_schedule_key_from_ini,
+    encode_schedule_key_for_ini,
     is_valid_legacy_hhmm,
     parse_flexible_cron,
     parse_schedule_key,
@@ -160,7 +160,7 @@ class TestParseFlexibleCron:
             "start_date": "2027-01-01"
         }
 
-    def test_start_date_detected(self):
+    def test_end_date_detected(self):
         assert parse_flexible_cron("end:2027-01-01") == {
             "end_date": "2027-01-01"
         }


### PR DESCRIPTION
## What this changes

Adds a flexible cron format: unordered fields with suffixes (9h, 30m, 15d, 3w for ISO week) plus month/day-of-week names, ordinal prefixes (1st/2nd/3rd/4th/5th/last), and optional start:/end: date bounds. The web viewer gets a new "Flexible (cron)" mode alongside the existing Advanced (cron) editor, and the edit modal now auto-detects which mode a stored schedule belongs to instead of always defaulting to Advanced. In addition, the month/day-of-week names can be used in regular cron entries and is suggested to avoid confusion. 

## Why

Standard 5-field cron cannot express schedules like "the 4th Tuesday of every month" or "the last Friday" — patterns that come up constantly for nets and other recurring meetings. Users were stuck hand-rolling day-of-month lists that drift across months with different lengths.

## Testing

Added unit tests for the flexible schedule code. Running live on my `meshcore-bot` instance. 

## Checklist

- [x] Branched from `dev` and targeting `dev`
- [x] `make test` passes
- [x] `make lint` passes (ruff + mypy)
- [x] Frontend lint passes if templates changed (`npm run lint:frontend`)
- [x] Tests added or updated for behavior changes
- [x] `CHANGELOG.md` updated under `## [Unreleased]` if user-visible
- [x] Config changes are reflected in `config.ini.example` (and the minimal/quickstart
      templates where relevant) — CI validates these with `validate_config.py --strict`
- [x] New docs pages are added to `nav:` in `mkdocs.yml`
- [ ] ~Any new command justifies its airtime and defaults conservatively~
