### PR TITLE
fix: Allow eslint to work in git worktrees

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "settings": {
     "html/html-extensions": [".html"]
   },
+  "root": true,
   "rules": {
     "no-undef": "warn",
     "no-unused-vars": "warn",


### PR DESCRIPTION
## What this changes

Prevent the running of `eslint` from finding `.eslintrc.json` in parent directories. 

## Why

Earlier when working on the `feat/flexible-scheduling` branch the `make lint` failed when `eslint` got confused on which html plugin to use (local work directory which is a git worktree and the parent directory which is the `dev` branch). 

## Testing

Well I am slightly confused now. When working on `feat/flexible-scheduling` I got around the problem by deleting the `.eslintrc.json` in the `dev` branch (parent directory). Linting then completed successfully.

On this branch I added the `root` attribute and checked out `.eslintrc.json` on the `dev` branch again. `make lint` completed successfully. Yea! I then removed the `root` attribute in this branch which should have cause `eslint` to fail again, but it completed successfully. I then went back to the `feat/flexible-scheduling` branch to try linting again and it completed successfully. ARG! 
 
I can not verify that this fix actually worked or not. Figure you might have better knowledge of `eslint` and have better knowledge. The only other thing I can try is to clone the repo in a completely new location create a worktree to test if it fails. If it does not fail then this PR is probably moot. I will give that a try and report back in a few minutes. 
 
## Checklist

- [x] Branched from `dev` and targeting `dev`
- [ ] ~`make test` passes~
- [x] `make lint` passes (ruff + mypy)
- [ ] ~Frontend lint passes if templates changed (`npm run lint:frontend`)~
- [ ] ~Tests added or updated for behavior changes~
- [ ] ~`CHANGELOG.md` updated under `## [Unreleased]` if user-visible~
- [ ] ~Config changes are reflected in `config.ini.example` (and the minimal/quickstart
      templates where relevant) — CI validates these with `validate_config.py --strict`~
- [ ] ~New docs pages are added to `nav:` in `mkdocs.yml`~
- [ ] ~Any new command justifies its airtime and defaults conservatively~
