### PR TITLE
feat(i18n): Add support for local translation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ semantic versioning.
   and Configuration now sit under a single **Settings** gear menu, leaving Dashboard,
   Real-time, Contacts, Mesh Graph and Logs on the bar. The current page is highlighted,
   including the gear when a settings page is open.
+- Added notes on connecting to waev.app MQTT brokers to the `packet_capture.md` file.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,7 @@ semantic versioning.
   and Configuration now sit under a single **Settings** gear menu, leaving Dashboard,
   Real-time, Contacts, Mesh Graph and Logs on the bar. The current page is highlighted,
   including the gear when a settings page is open.
-- Added notes on connecting to waev.app MQTT brokers to the `packet_capture.md` file.
+- Added notes on connecting to waev.app MQTT brokers to `docs/packet-capture.md`.
 
 ### Added
 
@@ -221,10 +221,12 @@ semantic versioning.
   from the MeshCore RF node, which is useful when one bot name is already taken
   by the radio's advertised name. Unset (the default) keeps the previous
   behavior: the connected device name, falling back to `[Bot] bot_name`.
-- Localization extended to read and merge local translation files with distributed
-  translation files. Defaults to `local/translations/` and allows translation
-  files to be build for local commands.
-
+- `local_translation_path` in `[Localization]` points at your own translation
+  catalog, merged over the distributed one key by key, so you can translate a
+  local command or override a single shipped string without editing a file that
+  an upgrade will replace. Defaults to the `translations/` directory inside
+  `[Bot] local_dir_path`, resolved to an absolute path so it does not depend on
+  the working directory.
 
 ## [1.0.0] — 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,10 @@ semantic versioning.
   from the MeshCore RF node, which is useful when one bot name is already taken
   by the radio's advertised name. Unset (the default) keeps the previous
   behavior: the connected device name, falling back to `[Bot] bot_name`.
+- Localization extended to read and merge local translation files with distributed
+  translation files. Defaults to `local/translations/` and allows translation
+  files to be build for local commands.
+
 
 ## [1.0.0] — 2026-08-07
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -111,7 +111,7 @@ message_correlation_timeout = 10.0
 enable_enhanced_correlation = true
 
 # Bot node ID (leave empty for auto-assignment)
-node_id =
+node_id = 
 
 # Command prefix (optional). Single prefix (!), multiple decorative (!~.),
 # or comma-separated (!, ~, .). First is shown in help/docs.
@@ -187,7 +187,7 @@ dm_flood_after = 2
 # Timezone for bot operations
 # Use standard timezone names (e.g., America/New_York, Europe/London, UTC)
 # Leave empty to use system timezone
-timezone =
+timezone = 
 
 # Bot location for geographic proximity calculations and astronomical data
 # Default latitude for bot location (decimal degrees)
@@ -328,11 +328,11 @@ language = en
 # Default: translations/
 translation_path = translations/
 
-# Path to local translation files directory (relative to bot root)
-# These translation files are merged with the translation files that
-# are distributed with the bot sources.
-# Default: local/translations/
-local_translation_path = local/translations/
+# Path to your own translation files, merged over the distributed ones key by key.
+# Use it to translate local commands, or to override individual strings, without
+# editing a shipped file. Defaults to the translations/ directory inside
+# [Bot] local_dir_path.
+# local_translation_path = local/translations/
 
 # Automatically reply in the language of the incoming message.
 # When enabled, greeting-style commands detect the sender's language (from a
@@ -349,13 +349,13 @@ auto_detect_language = false
 # - Public keys MUST be exactly 64 hexadecimal characters (ed25519 format)
 # - Invalid formats will be rejected with error logs
 # - Empty or whitespace-only values disable admin access
-# - Keys are case-insensitive (normalized to lowercase)
+# - Keys are case-insensitive (normalized to lowercase)  
 #
 # Format: comma-separated list of 64-character hex public keys (without spaces)
 # Example: f5d2b56d19b24412756933e917d4632e088cdd5daeadc9002feca73bf5d2b56d,1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 #
 # IMPORTANT: Leave blank to disable all admin commands. Set your actual admin pubkey(s) here.
-admin_pubkeys =
+admin_pubkeys = 
 
 # Commands that require admin access (comma-separated)
 # These commands will only work for users in the admin_pubkeys list
@@ -368,13 +368,13 @@ admin_commands = repeater,webviewer,reload,channelpause,neighbors
 # Format: command_name = alternative_file_name
 # The alternative_file_name should be the name of a Python file (without .py extension)
 # in the modules/commands/alternatives/ directory
-#
+# 
 # Example: To use an alternative weather plugin for international users:
 # wx = wx_international
-#
+# 
 # This will replace the default wx command with the plugin from
 # modules/commands/alternatives/wx_international.py
-#
+# 
 # Note: The alternative plugin must have the same 'name' metadata as the command
 # it's replacing, or the override will use the alternative plugin's name instead.
 #
@@ -433,7 +433,7 @@ companion_min_inactive_days = 30
 #
 # To use a literal backslash + n, use \\n (double backslash + n)
 # Other escape sequences: \t (tab), \r (carriage return), \\ (literal backslash)
-#
+# 
 # Available placeholders (mesh network info - same as Scheduled_Messages):
 # Total counts (ever heard):
 # {total_contacts} - Total number of contacts ever heard
@@ -441,23 +441,23 @@ companion_min_inactive_days = 30
 # {total_companions} - Total number of companion devices ever heard
 # {total_roomservers} - Total number of roomserver devices ever heard
 # {total_sensors} - Total number of sensor devices ever heard
-#
+# 
 # Recent activity:
 # {recent_activity_24h} - Number of unique users active in last 24 hours
-#
+# 
 # Active in last 30 days (last_heard):
 # {total_contacts_30d} - Total contacts active (last_heard) in last 30 days
 # {total_repeaters_30d} - Total repeaters active (last_heard) in last 30 days
 # {total_companions_30d} - Total companions active (last_heard) in last 30 days
 # {total_roomservers_30d} - Total roomservers active (last_heard) in last 30 days
 # {total_sensors_30d} - Total sensors active (last_heard) in last 30 days
-#
+# 
 # New devices (first heard in last 7 days):
 # {new_companions_7d} - New companion devices first heard in last 7 days
 # {new_repeaters_7d} - New repeater devices first heard in last 7 days
 # {new_roomservers_7d} - New roomserver devices first heard in last 7 days
 # {new_sensors_7d} - New sensor devices first heard in last 7 days
-#
+# 
 # Legacy placeholders (for backward compatibility):
 # {repeaters} - Same as {total_repeaters}
 # {companions} - Same as {total_companions}
@@ -563,36 +563,35 @@ category.funfact = fun
 #   - The command's own cooldown still applies. If it is on cooldown when the schedule
 #     fires, the placeholder expands to nothing that round.
 #
-#
 # Available placeholders for mesh network information:
-#
+# 
 # Total counts (ever heard):
 # {total_contacts} - Total number of contacts ever heard
 # {total_repeaters} - Total number of repeater devices ever heard
 # {total_companions} - Total number of companion devices ever heard
 # {total_roomservers} - Total number of roomserver devices ever heard
 # {total_sensors} - Total number of sensor devices ever heard
-#
+# 
 # Recent activity:
 # {recent_activity_24h} - Number of unique users active in last 24 hours
-#
+# 
 # Active in last 30 days (last_heard):
 # {total_contacts_30d} - Total contacts active (last_heard) in last 30 days
 # {total_repeaters_30d} - Total repeaters active (last_heard) in last 30 days
 # {total_companions_30d} - Total companions active (last_heard) in last 30 days
 # {total_roomservers_30d} - Total roomservers active (last_heard) in last 30 days
 # {total_sensors_30d} - Total sensors active (last_heard) in last 30 days
-#
+# 
 # New devices (first heard in last 7 days):
 # {new_companions_7d} - New companion devices first heard in last 7 days
 # {new_repeaters_7d} - New repeater devices first heard in last 7 days
 # {new_roomservers_7d} - New roomserver devices first heard in last 7 days
 # {new_sensors_7d} - New sensor devices first heard in last 7 days
-#
+# 
 # Legacy placeholders (for backward compatibility):
 # {repeaters} - Same as {total_repeaters}
 # {companions} - Same as {total_companions}
-#
+# 
 # Example with placeholders (cron):
 # 0 8 * * * = Public:Good morning! Network: {total_contacts} total ({total_repeaters} repeaters, {total_companions} companions). {new_repeaters_7d} new repeaters, {new_companions_7d} new companions in last 7d. {recent_activity_24h} active in 24h.
 # Example with 30-day active devices and new devices in 7d:
@@ -651,37 +650,42 @@ log_max_bytes = 5242880
 # log_backup_count: number of rotated backup files to keep (e.g. meshcore_bot.log.1 … .3)
 log_backup_count = 3
 [External_Data]
-# URL shortener API base (v.gd / is.gd-compatible create.php). Default: https://v.gd
-# See https://v.gd/apishorteningreference.php
+# URL shortener service: gd (v.gd / is.gd-compatible) or shlink. Default: gd
+short_url_website_service = gd
+# URL shortener API base. For gd this is the create.php host (default https://v.gd,
+# see https://v.gd/apishorteningreference.php). For shlink it is your own instance's
+# base URL and is REQUIRED -- there is no default, and the bot refuses to shorten
+# rather than send your API key to a host you did not configure.
 short_url_website = https://v.gd
-# Optional API key for alternate shortener hosts (unused for public v.gd/is.gd)
-short_url_website_api_key =
+# API key. Optional for gd (unused for public v.gd/is.gd, appended as ?key= for
+# alternate hosts). Required for shlink, where it is sent as an X-Api-Key header.
+short_url_website_api_key = 
 
 # Weather API key (future feature)
-weather_api_key =
+weather_api_key = 
 
 # Weather update interval in seconds (future feature)
 weather_update_interval = 3600
 
 # Tide API key (future feature)
-tide_api_key =
+tide_api_key = 
 
 # Tide update interval in seconds (future feature)
 tide_update_interval = 1800
 
 # N2YO API key for satellite pass information
 # Get free key at: https://www.n2yo.com/login/
-n2yo_api_key =
+n2yo_api_key = 
 
 # AirNow API key for AQI data
 # Get free key at: https://docs.airnowapi.org/
-airnow_api_key =
+airnow_api_key = 
 
 # Forecast.Solar API key for solar forecast data
 # Get key at: https://forecast.solar/ (free tier works without key, paid tier for 3+ day forecasts)
 # Free tier: 2-day forecast, 1-hour resolution
 # Paid tier (14 EUR/year): 3-6 day forecast, 15-30 minute resolution
-forecast_solar_api_key =
+forecast_solar_api_key = 
 
 # Optional external repeater-prefix API for the prefix command.
 #
@@ -696,9 +700,6 @@ forecast_solar_api_key =
 # Fetched with a plain GET, must answer HTTP 200 with that JSON, 10s timeout.
 # "prefix" is upper-cased by the bot; "node_count" is an int; "node_names" a list.
 # Responses are cached for repeater_prefix_cache_hours below.
-# Repeater prefix API URL for prefix command
-# Leave empty to disable prefix command functionality
-# Configure your own regional API endpoint
 repeater_prefix_api_url = 
 
 # Repeater prefix cache duration in hours
@@ -816,11 +817,18 @@ wind_speed_unit = mph
 # Default: inch
 precipitation_unit = inch
 
+# Note: gwx shows visibility in km when temperature_unit = celsius, miles
+# otherwise. The pressure unit follows the language instead (mmHg for ru,
+# hPa elsewhere) since that is a locale convention, not a metric/imperial split.
+
 # How to show daily high/low temperatures (wx, gwx, Weather_Service).
 # Placeholders: {high} {low} {units}  ({units} is °F or °C)
-temperature_high_low_format = H:{high}{units} L:{low}{units}
-temperature_high_only_format = H:{high}{units}
-temperature_low_only_format = L:{low}{units}
+#               {high_label} {low_label}  (localized H/L, per [Localization] language)
+# Keep {high_label}/{low_label} to follow the configured language; hardcode
+# H:/L: only if you want English labels regardless of language.
+temperature_high_low_format = {high_label}:{high}{units} {low_label}:{low}{units}
+temperature_high_only_format = {high_label}:{high}{units}
+temperature_low_only_format = {low_label}:{low}{units}
 # Examples:
 # temperature_high_low_format = ↓{low}°↑{high}{units}
 # temperature_high_low_format = H:{high}{units} L:{low}{units}
@@ -1053,6 +1061,8 @@ enable_p_shortcut = true
 # Only the first RF chunk includes the prefix when the reply is split.
 # Example: @[{sender}]
 # Example: {path_distance|prefix_if_nonempty:\U0001F4CF }
+# Filter arguments may be double-quoted to end them explicitly and allow further
+# filters afterwards: {path_distance|prefix_if_nonempty:"\U0001F4CF "|hops_min:1}
 reply_prefix =
 
 # Bytes per hop required before resolving repeater names from the database.
@@ -1072,7 +1082,7 @@ path_selection_preset = balanced
 
 # Basic Settings
 # Geographic proximity calculation method
-# simple: Use proximity to bot location
+# simple: Use proximity to bot location 
 # path: Use proximity to previous/next nodes in the path for more realistic routing (default)
 proximity_method = path
 
@@ -1321,7 +1331,7 @@ enabled = false
 # Comma-separated list to restrict to specific channels (only greeter command works there)
 # Example: channels = general,welcome,newbies
 # If not specified, uses the channels from [Channels] monitor_channels setting
-# channels =
+# channels = 
 
 # Greeting message template (default for all channels)
 # Available fields: {sender} - the user's name/ID
@@ -1339,7 +1349,7 @@ greeting_message = Welcome to the mesh, @[{sender}]!
 # channel name. (So avoid text like ", wx: sunny" if wx is also a channel.)
 # Multi-part greetings are supported per channel using pipe (|) separator
 # Leave empty to use greeting_message for all channels
-channel_greetings =
+channel_greetings = 
 
 # Per-channel greetings (tracking behavior)
 # false: Greet each user only once globally (default - user gets one greeting total)
@@ -1424,7 +1434,7 @@ enabled = false
 # Format: comma-separated list of 64-character hex public keys (without spaces)
 # Example: f5d2b56d19b24412756933e917d4632e088cdd5daeadc9002feca73bf5d2b56d
 # Leave empty to only use Admin_ACL members
-announcements_acl =
+announcements_acl = 
 
 # Default channel for announcements when no channel is specified
 # Announcements will be sent to this channel if no channel is provided
@@ -1567,7 +1577,9 @@ require_path_bytes_failure_response =
 # {firstlast_distance} requires at least two path nodes with stored repeater/roomserver coordinates.
 # Pipe filters (feed-style), e.g. only show cumulative path distance when hops are multibyte (2+ bytes per hop):
 # response_format = ack @[{sender}]{phrase_part} | {connection_info}{path_distance|pathbytes_min:2|prefix_if_nonempty: | Path Dist: }| F/L Dist: {firstlast_distance} | {elapsed} | Rec: {timestamp}
-# Filters: pathbytes_min:N (alias pathbytes:N) clears the field unless bytes_per_hop >= N; hops_min:N clears it unless the message travelled at least N hops; prefix_if_nonempty:L prepends literal L when value non-empty after prior filters. If L contains |, put prefix_if_nonempty last in that placeholder (it consumes the rest of the chain as its literal).
+# Filters: pathbytes_min:N (alias pathbytes:N) clears the field unless bytes_per_hop >= N; hops_min:N clears it unless the message travelled at least N hops; prefix_if_nonempty:L prepends literal L when value non-empty after prior filters; if_nonempty:L (alias if_notempty:L) replaces the value with literal L when non-empty; shorten (alias shorten_url) runs the value through the [External_Data] shortener, falling back to the original on failure.
+# A filter argument may be double-quoted, which ends it at the closing quote so more filters can follow, and may contain nested {field} placeholders: prefix_if_nonempty:"Dist {sender}: "|hops_min:1
+# An UNQUOTED prefix_if_nonempty:L consumes the rest of the chain as its literal, so L may contain | but the filter must come last in that placeholder.
 # hops_min asks about the route, pathbytes_min about how it is encoded. Use hops_min:1 to drop a
 # distance clause on a direct message without also dropping a measurable one-byte multi-hop path.
 # The distance placeholders render "N/A" on a direct message, which is non-empty, so
@@ -1760,7 +1772,7 @@ mesh_graph_cache_seconds = 30
 #
 # Note: Only hashtag channels work here - custom channels with private keys
 # must be added to the radio itself.
-decode_hashtag_channels =
+decode_hashtag_channels = 
 
 ####################################################################################################
 #                                                                                                  #
@@ -1776,7 +1788,7 @@ enabled = false
 # Output file for packet data (optional)
 # Leave empty to disable file output
 # Packets will be written as JSON lines
-output_file =
+output_file = 
 
 # Verbose output (show JSON packet data in logs)
 # true: Show packet data in logs
@@ -1908,7 +1920,7 @@ neighbors_self_scopes =
 owner_public_key =
 
 # Owner email address
-owner_email =
+owner_email = 
 
 # Private key file path for auth token generation (fallback if device signing unavailable)
 # Optional - on-device signing is preferred
@@ -1916,7 +1928,7 @@ owner_email =
 # Required only if device doesn't support on-device signing or auth_token_method = python
 # Note: If not provided and auth_token_method = python, the service will attempt to fetch
 # the private key from the device automatically
-private_key_path =
+private_key_path = 
 
 # Auth token signing method
 # device: Try on-device signing first, fallback to Python signing (default, recommended)
@@ -2012,8 +2024,8 @@ mqtt2_token_audience = mqtt-eu-v1.letsmesh.net
 mqtt2_topic_status = meshcore/{IATA}/{PUBLIC_KEY}/status
 mqtt2_topic_packets = meshcore/{IATA}/{PUBLIC_KEY}/packets
 mqtt2_websocket_path = /mqtt
-mqtt2_client_id =
-mqtt2_upload_packet_types =
+mqtt2_client_id = 
+mqtt2_upload_packet_types = 
 
 # Stats and status publishing
 # Enable stats in status messages
@@ -2050,7 +2062,7 @@ api_url = https://map.meshcore.dev/api/v1/uploader/node
 # If not provided, the service will attempt to fetch the private key from the device
 # Supports 64-byte orlp format (128 hex chars) or 32-byte seed (64 hex chars)
 # Required only if device doesn't support private key export
-private_key_path =
+private_key_path = 
 
 # Minimum time between re-uploads of same node (seconds)
 # Prevents uploading the same node too frequently to avoid API spam
@@ -2082,10 +2094,10 @@ weather_alarm = 6:00
 
 # Bot position for weather forecasts and alerts
 # Latitude in decimal degrees
-my_position_lat =
+my_position_lat = 
 
 # Longitude in decimal degrees
-my_position_lon =
+my_position_lon = 
 
 # Channel for daily weather forecasts
 # Weather forecasts will be sent to this channel

--- a/config.ini.example
+++ b/config.ini.example
@@ -111,7 +111,7 @@ message_correlation_timeout = 10.0
 enable_enhanced_correlation = true
 
 # Bot node ID (leave empty for auto-assignment)
-node_id = 
+node_id =
 
 # Command prefix (optional). Single prefix (!), multiple decorative (!~.),
 # or comma-separated (!, ~, .). First is shown in help/docs.
@@ -187,7 +187,7 @@ dm_flood_after = 2
 # Timezone for bot operations
 # Use standard timezone names (e.g., America/New_York, Europe/London, UTC)
 # Leave empty to use system timezone
-timezone = 
+timezone =
 
 # Bot location for geographic proximity calculations and astronomical data
 # Default latitude for bot location (decimal degrees)
@@ -328,6 +328,12 @@ language = en
 # Default: translations/
 translation_path = translations/
 
+# Path to local translation files directory (relative to bot root)
+# These translation files are merged with the translation files that
+# are distributed with the bot sources.
+# Default: local/translations/
+local_translation_path = local/translations/
+
 # Automatically reply in the language of the incoming message.
 # When enabled, greeting-style commands detect the sender's language (from a
 # built-in keyword list, plus the optional langdetect package for longer text:
@@ -343,13 +349,13 @@ auto_detect_language = false
 # - Public keys MUST be exactly 64 hexadecimal characters (ed25519 format)
 # - Invalid formats will be rejected with error logs
 # - Empty or whitespace-only values disable admin access
-# - Keys are case-insensitive (normalized to lowercase)  
+# - Keys are case-insensitive (normalized to lowercase)
 #
 # Format: comma-separated list of 64-character hex public keys (without spaces)
 # Example: f5d2b56d19b24412756933e917d4632e088cdd5daeadc9002feca73bf5d2b56d,1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
 #
 # IMPORTANT: Leave blank to disable all admin commands. Set your actual admin pubkey(s) here.
-admin_pubkeys = 
+admin_pubkeys =
 
 # Commands that require admin access (comma-separated)
 # These commands will only work for users in the admin_pubkeys list
@@ -362,13 +368,13 @@ admin_commands = repeater,webviewer,reload,channelpause,neighbors
 # Format: command_name = alternative_file_name
 # The alternative_file_name should be the name of a Python file (without .py extension)
 # in the modules/commands/alternatives/ directory
-# 
+#
 # Example: To use an alternative weather plugin for international users:
 # wx = wx_international
-# 
+#
 # This will replace the default wx command with the plugin from
 # modules/commands/alternatives/wx_international.py
-# 
+#
 # Note: The alternative plugin must have the same 'name' metadata as the command
 # it's replacing, or the override will use the alternative plugin's name instead.
 #
@@ -427,7 +433,7 @@ companion_min_inactive_days = 30
 #
 # To use a literal backslash + n, use \\n (double backslash + n)
 # Other escape sequences: \t (tab), \r (carriage return), \\ (literal backslash)
-# 
+#
 # Available placeholders (mesh network info - same as Scheduled_Messages):
 # Total counts (ever heard):
 # {total_contacts} - Total number of contacts ever heard
@@ -435,23 +441,23 @@ companion_min_inactive_days = 30
 # {total_companions} - Total number of companion devices ever heard
 # {total_roomservers} - Total number of roomserver devices ever heard
 # {total_sensors} - Total number of sensor devices ever heard
-# 
+#
 # Recent activity:
 # {recent_activity_24h} - Number of unique users active in last 24 hours
-# 
+#
 # Active in last 30 days (last_heard):
 # {total_contacts_30d} - Total contacts active (last_heard) in last 30 days
 # {total_repeaters_30d} - Total repeaters active (last_heard) in last 30 days
 # {total_companions_30d} - Total companions active (last_heard) in last 30 days
 # {total_roomservers_30d} - Total roomservers active (last_heard) in last 30 days
 # {total_sensors_30d} - Total sensors active (last_heard) in last 30 days
-# 
+#
 # New devices (first heard in last 7 days):
 # {new_companions_7d} - New companion devices first heard in last 7 days
 # {new_repeaters_7d} - New repeater devices first heard in last 7 days
 # {new_roomservers_7d} - New roomserver devices first heard in last 7 days
 # {new_sensors_7d} - New sensor devices first heard in last 7 days
-# 
+#
 # Legacy placeholders (for backward compatibility):
 # {repeaters} - Same as {total_repeaters}
 # {companions} - Same as {total_companions}
@@ -557,35 +563,36 @@ category.funfact = fun
 #   - The command's own cooldown still applies. If it is on cooldown when the schedule
 #     fires, the placeholder expands to nothing that round.
 #
+#
 # Available placeholders for mesh network information:
-# 
+#
 # Total counts (ever heard):
 # {total_contacts} - Total number of contacts ever heard
 # {total_repeaters} - Total number of repeater devices ever heard
 # {total_companions} - Total number of companion devices ever heard
 # {total_roomservers} - Total number of roomserver devices ever heard
 # {total_sensors} - Total number of sensor devices ever heard
-# 
+#
 # Recent activity:
 # {recent_activity_24h} - Number of unique users active in last 24 hours
-# 
+#
 # Active in last 30 days (last_heard):
 # {total_contacts_30d} - Total contacts active (last_heard) in last 30 days
 # {total_repeaters_30d} - Total repeaters active (last_heard) in last 30 days
 # {total_companions_30d} - Total companions active (last_heard) in last 30 days
 # {total_roomservers_30d} - Total roomservers active (last_heard) in last 30 days
 # {total_sensors_30d} - Total sensors active (last_heard) in last 30 days
-# 
+#
 # New devices (first heard in last 7 days):
 # {new_companions_7d} - New companion devices first heard in last 7 days
 # {new_repeaters_7d} - New repeater devices first heard in last 7 days
 # {new_roomservers_7d} - New roomserver devices first heard in last 7 days
 # {new_sensors_7d} - New sensor devices first heard in last 7 days
-# 
+#
 # Legacy placeholders (for backward compatibility):
 # {repeaters} - Same as {total_repeaters}
 # {companions} - Same as {total_companions}
-# 
+#
 # Example with placeholders (cron):
 # 0 8 * * * = Public:Good morning! Network: {total_contacts} total ({total_repeaters} repeaters, {total_companions} companions). {new_repeaters_7d} new repeaters, {new_companions_7d} new companions in last 7d. {recent_activity_24h} active in 24h.
 # Example with 30-day active devices and new devices in 7d:
@@ -648,33 +655,33 @@ log_backup_count = 3
 # See https://v.gd/apishorteningreference.php
 short_url_website = https://v.gd
 # Optional API key for alternate shortener hosts (unused for public v.gd/is.gd)
-short_url_website_api_key = 
+short_url_website_api_key =
 
 # Weather API key (future feature)
-weather_api_key = 
+weather_api_key =
 
 # Weather update interval in seconds (future feature)
 weather_update_interval = 3600
 
 # Tide API key (future feature)
-tide_api_key = 
+tide_api_key =
 
 # Tide update interval in seconds (future feature)
 tide_update_interval = 1800
 
 # N2YO API key for satellite pass information
 # Get free key at: https://www.n2yo.com/login/
-n2yo_api_key = 
+n2yo_api_key =
 
 # AirNow API key for AQI data
 # Get free key at: https://docs.airnowapi.org/
-airnow_api_key = 
+airnow_api_key =
 
 # Forecast.Solar API key for solar forecast data
 # Get key at: https://forecast.solar/ (free tier works without key, paid tier for 3+ day forecasts)
 # Free tier: 2-day forecast, 1-hour resolution
 # Paid tier (14 EUR/year): 3-6 day forecast, 15-30 minute resolution
-forecast_solar_api_key = 
+forecast_solar_api_key =
 
 # Optional external repeater-prefix API for the prefix command.
 #
@@ -689,6 +696,9 @@ forecast_solar_api_key =
 # Fetched with a plain GET, must answer HTTP 200 with that JSON, 10s timeout.
 # "prefix" is upper-cased by the bot; "node_count" is an int; "node_names" a list.
 # Responses are cached for repeater_prefix_cache_hours below.
+# Repeater prefix API URL for prefix command
+# Leave empty to disable prefix command functionality
+# Configure your own regional API endpoint
 repeater_prefix_api_url = 
 
 # Repeater prefix cache duration in hours
@@ -1062,7 +1072,7 @@ path_selection_preset = balanced
 
 # Basic Settings
 # Geographic proximity calculation method
-# simple: Use proximity to bot location 
+# simple: Use proximity to bot location
 # path: Use proximity to previous/next nodes in the path for more realistic routing (default)
 proximity_method = path
 
@@ -1311,7 +1321,7 @@ enabled = false
 # Comma-separated list to restrict to specific channels (only greeter command works there)
 # Example: channels = general,welcome,newbies
 # If not specified, uses the channels from [Channels] monitor_channels setting
-# channels = 
+# channels =
 
 # Greeting message template (default for all channels)
 # Available fields: {sender} - the user's name/ID
@@ -1329,7 +1339,7 @@ greeting_message = Welcome to the mesh, @[{sender}]!
 # channel name. (So avoid text like ", wx: sunny" if wx is also a channel.)
 # Multi-part greetings are supported per channel using pipe (|) separator
 # Leave empty to use greeting_message for all channels
-channel_greetings = 
+channel_greetings =
 
 # Per-channel greetings (tracking behavior)
 # false: Greet each user only once globally (default - user gets one greeting total)
@@ -1414,7 +1424,7 @@ enabled = false
 # Format: comma-separated list of 64-character hex public keys (without spaces)
 # Example: f5d2b56d19b24412756933e917d4632e088cdd5daeadc9002feca73bf5d2b56d
 # Leave empty to only use Admin_ACL members
-announcements_acl = 
+announcements_acl =
 
 # Default channel for announcements when no channel is specified
 # Announcements will be sent to this channel if no channel is provided
@@ -1750,7 +1760,7 @@ mesh_graph_cache_seconds = 30
 #
 # Note: Only hashtag channels work here - custom channels with private keys
 # must be added to the radio itself.
-decode_hashtag_channels = 
+decode_hashtag_channels =
 
 ####################################################################################################
 #                                                                                                  #
@@ -1766,7 +1776,7 @@ enabled = false
 # Output file for packet data (optional)
 # Leave empty to disable file output
 # Packets will be written as JSON lines
-output_file = 
+output_file =
 
 # Verbose output (show JSON packet data in logs)
 # true: Show packet data in logs
@@ -1898,7 +1908,7 @@ neighbors_self_scopes =
 owner_public_key =
 
 # Owner email address
-owner_email = 
+owner_email =
 
 # Private key file path for auth token generation (fallback if device signing unavailable)
 # Optional - on-device signing is preferred
@@ -1906,7 +1916,7 @@ owner_email =
 # Required only if device doesn't support on-device signing or auth_token_method = python
 # Note: If not provided and auth_token_method = python, the service will attempt to fetch
 # the private key from the device automatically
-private_key_path = 
+private_key_path =
 
 # Auth token signing method
 # device: Try on-device signing first, fallback to Python signing (default, recommended)
@@ -2002,8 +2012,8 @@ mqtt2_token_audience = mqtt-eu-v1.letsmesh.net
 mqtt2_topic_status = meshcore/{IATA}/{PUBLIC_KEY}/status
 mqtt2_topic_packets = meshcore/{IATA}/{PUBLIC_KEY}/packets
 mqtt2_websocket_path = /mqtt
-mqtt2_client_id = 
-mqtt2_upload_packet_types = 
+mqtt2_client_id =
+mqtt2_upload_packet_types =
 
 # Stats and status publishing
 # Enable stats in status messages
@@ -2040,7 +2050,7 @@ api_url = https://map.meshcore.dev/api/v1/uploader/node
 # If not provided, the service will attempt to fetch the private key from the device
 # Supports 64-byte orlp format (128 hex chars) or 32-byte seed (64 hex chars)
 # Required only if device doesn't support private key export
-private_key_path = 
+private_key_path =
 
 # Minimum time between re-uploads of same node (seconds)
 # Prevents uploading the same node too frequently to avoid API spam
@@ -2072,10 +2082,10 @@ weather_alarm = 6:00
 
 # Bot position for weather forecasts and alerts
 # Latitude in decimal degrees
-my_position_lat = 
+my_position_lat =
 
 # Longitude in decimal degrees
-my_position_lon = 
+my_position_lon =
 
 # Channel for daily weather forecasts
 # Weather forecasts will be sent to this channel

--- a/docs/packet-capture.md
+++ b/docs/packet-capture.md
@@ -175,6 +175,13 @@ jwt_renewal_interval = 43200      # Default proactive refresh cadence (12 hours)
 # mqtt1_jwt_renewal_interval = 1800
 ```
 
+**Note**: When connecting to waev.app brokers the default settings will cause the connection not to authenticate properly. Please use the following settings on the MQTT connection for the waev.app brokers.
+
+```ini
+mqttN_jwt_ttl_seconds = 3600
+mqttN_jwt_renewal_interval = 3500
+```
+
 ---
 
 ## Packet Format
@@ -309,6 +316,8 @@ followed immediately by `✓ Connected to MQTT broker`, over and over:
 Note that `rc=` on a *disconnect* is a paho `MQTT_ERR_*` code, not a CONNACK code:
 `rc=7` is a lost connection and `rc=2` is a protocol error. They do not mean the same
 thing as the numbers in a `Failed to connect` line.
+
+**Note**: If the MQTT connection that is failing is attempting to connect to waev.app brokers, please see the [Status Publishing and MQTT auth (JWT)](#status-publishing-and-mqtt-auth-jwt) section.
 
 ### No Packets Being Published
 

--- a/modules/config_schema.py
+++ b/modules/config_schema.py
@@ -213,6 +213,7 @@ SECTIONS: dict[str, SectionMeta] = {
     "Localization": SectionMeta(keys={
         "language": KeyMeta(default="en"),
         "translation_path": KeyMeta(default="translations/"),
+        "local_translation_path": KeyMeta(default="<local_dir_path>/translations"),
         "auto_detect_language": KeyMeta(type="bool", default="false"),
     }),
     "Webhook": SectionMeta(keys={

--- a/modules/core.py
+++ b/modules/core.py
@@ -280,14 +280,17 @@ class MeshCoreBot:
         # Initialize translator for localization BEFORE CommandManager
         # This ensures translated keywords are available when commands are loaded
         try:
+            default_local_translations = self._default_local_translation_path(self.config)
             if self.config.has_section('Localization'):
                 language = self.config.get('Localization', 'language', fallback='en')
                 translation_path = self.config.get('Localization', 'translation_path', fallback='translations/')
-                local_translation_path = self.config.get('Localization', 'local_translation_path', fallback='local/translations/')
+                local_translation_path = self.config.get(
+                    'Localization', 'local_translation_path', fallback=default_local_translations
+                )
             else:
                 language = 'en'
                 translation_path = 'translations/'
-                local_translation_path = 'local/translations/'
+                local_translation_path = default_local_translations
             self.translation_path = translation_path
             self.local_translation_path = local_translation_path
             self._translator_cache: dict[str, Any] = {}
@@ -312,6 +315,9 @@ class MeshCoreBot:
 
             self.translator = DummyTranslator()
             self.translation_path = 'translations/'
+            # get_translator() reads both paths when it builds a per-language
+            # translator, so neither may be left unset here.
+            self.local_translation_path = 'local/translations/'
             self._translator_cache = {}
 
         # Initialize solar conditions configuration
@@ -433,6 +439,17 @@ class MeshCoreBot:
                 'Connection', 'command_min_interval_ms', fallback=30.0
             ) / 1000.0,
         )
+
+    def _default_local_translation_path(self, config: configparser.ConfigParser) -> str:
+        """Default local catalog directory: ``<local_dir_path>/translations``.
+
+        ``local_dir_path`` already selects where an operator's own commands, service
+        plugins and config overlay live, so the local translation catalog belongs in
+        that same tree rather than in a second, separately-configured location. The
+        result is absolute, so it does not depend on the process's cwd.
+        """
+        local_dir = config.get('Bot', 'local_dir_path', fallback='local')
+        return str(Path(resolve_path(local_dir, self.bot_root)) / 'translations')
 
     @property
     def bot_root(self) -> Path:
@@ -624,7 +641,9 @@ class MeshCoreBot:
         if cached is not None:
             return cached
         try:
-            translator = Translator(resolved_language, self.translation_path)
+            translator = Translator(
+                resolved_language, self.translation_path, self.local_translation_path
+            )
         except (OSError, ValueError, FileNotFoundError, json.JSONDecodeError) as e:
             self.logger.warning(
                 "Failed to build translator for %r: %s", resolved_language, e
@@ -848,7 +867,14 @@ class MeshCoreBot:
                 new_translation_path = new_config.get(
                     'Localization', 'translation_path', fallback='translations/'
                 )
-                new_translator = Translator(new_language, new_translation_path)
+                new_local_translation_path = new_config.get(
+                    'Localization',
+                    'local_translation_path',
+                    fallback=self._default_local_translation_path(new_config),
+                )
+                new_translator = Translator(
+                    new_language, new_translation_path, new_local_translation_path
+                )
                 new_translator_cache = {new_language: new_translator}
 
                 old_state = {
@@ -863,6 +889,7 @@ class MeshCoreBot:
                     "tx_delay_ms": self.tx_delay_ms,
                     "translator": self.translator,
                     "translation_path": self.translation_path,
+                    "local_translation_path": self.local_translation_path,
                     "translator_cache": self._translator_cache,
                     "command_config_state": self._command_config_state(
                         self.command_manager
@@ -885,6 +912,7 @@ class MeshCoreBot:
                     self.channel_rate_limiter = new_channel_rate_limiter
                     self.tx_delay_ms = new_tx_delay_ms
                     self.translation_path = new_translation_path
+                    self.local_translation_path = new_local_translation_path
                     self._translator_cache = new_translator_cache
                     self.translator = new_translator
                     # Commands and nested delegates require the real bot. They
@@ -933,6 +961,7 @@ class MeshCoreBot:
                     self.tx_delay_ms = old_state["tx_delay_ms"]
                     self.translator = old_state["translator"]
                     self.translation_path = old_state["translation_path"]
+                    self.local_translation_path = old_state["local_translation_path"]
                     self._translator_cache = old_state["translator_cache"]
                     self._apply_command_config_state(
                         self.command_manager, old_state["command_config_state"]

--- a/modules/core.py
+++ b/modules/core.py
@@ -283,12 +283,15 @@ class MeshCoreBot:
             if self.config.has_section('Localization'):
                 language = self.config.get('Localization', 'language', fallback='en')
                 translation_path = self.config.get('Localization', 'translation_path', fallback='translations/')
+                local_translation_path = self.config.get('Localization', 'local_translation_path', fallback='local/translations/')
             else:
                 language = 'en'
                 translation_path = 'translations/'
+                local_translation_path = 'local/translations/'
             self.translation_path = translation_path
+            self.local_translation_path = local_translation_path
             self._translator_cache: dict[str, Any] = {}
-            self.translator = Translator(language, translation_path)
+            self.translator = Translator(language, translation_path, local_translation_path)
             self._translator_cache[language] = self.translator
             self.logger.info(f"Localization initialized: {language}")
         except (OSError, ValueError, FileNotFoundError, json.JSONDecodeError) as e:

--- a/modules/i18n.py
+++ b/modules/i18n.py
@@ -5,15 +5,17 @@ Provides translation functionality for bot commands and responses
 """
 
 import json
+import logging
 from importlib import resources
 from pathlib import Path
 from typing import Any
 
+logger = logging.getLogger("MeshCoreBot")
 
 class Translator:
     """Handles translation loading and lookup for the bot"""
 
-    def __init__(self, language: str = 'en', translation_path: str = 'translations/'):
+    def __init__(self, language: str = 'en', translation_path: str = 'translations/', local_translation_path: str = 'local/translations/'):
         """
         Initialize translator
 
@@ -24,6 +26,7 @@ class Translator:
         """
         self.language = language
         self.translation_path = translation_path
+        self.local_translation_path = local_translation_path
         self.base_language = self._extract_base_language(language)
         self.translations: dict[str, Any] = {}
         self.fallback_translations: dict[str, Any] = {}
@@ -98,9 +101,34 @@ class Translator:
         merge_dict(result, primary)
         return result
 
+    def _deep_merge_translations(self, primary: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+        """
+        Perform a deep merge of translations with overrides taking precedence
+
+        Args:
+            primary: Primary translation dictionary (may be empty)
+            override: Translation dictionary to apply to Primary and override
+                      just values, not sub-dictionaries
+
+        Returns:
+            Merged dictionary with primary values overridden by override dictionary
+        """
+        # Start with a copy of the first dictionary to avoid side effects
+        result = primary.copy()
+
+        for key, value in override.items():
+            # If both values are dictionaries, merge them recursively
+            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+                result[key] = self._deep_merge_translations(result[key], value)
+            else:
+                # Otherwise, overwrite the value or add the new key
+                result[key] = value
+
+        return result
+
     def _load_file(self, lang: str) -> dict[str, Any]:
         """
-        Load a single translation file
+        Load translation files from distribution then local
 
         Args:
             lang: Language code
@@ -109,13 +137,20 @@ class Translator:
             Dictionary of translations, empty dict if file not found
         """
         file_path = Path(self.translation_path) / f"{lang}.json"
+        local_file_path = Path(self.local_translation_path) / f"{lang}.json"
         try:
             # An explicitly configured filesystem catalog always wins.  The
             # package fallback makes the defaults work from an installed wheel
             # (where ``translations/`` is not relative to the current cwd).
-            if file_path.is_file():
-                with open(file_path, encoding='utf-8') as f:
-                    return json.load(f)
+            xlate_table: dict[str, str] = {}
+            for xlate_file in (file_path, local_file_path):
+                if xlate_file.is_file():
+                    logger.info(f"Loading translation file: {xlate_file}")
+                    with open(xlate_file, encoding='utf-8') as f:
+                        xlate_table = self._deep_merge_translations(xlate_table, json.load(f))
+            if xlate_table:
+                # if xlate_table has been built, return it
+                return xlate_table
 
             if not self._uses_bundled_defaults():
                 return {}

--- a/modules/i18n.py
+++ b/modules/i18n.py
@@ -22,7 +22,10 @@ class Translator:
         Args:
             language: Language code (e.g., 'en', 'es', 'es-MX', 'es-ES', 'fr', 'de')
                       Supports locale codes like 'es-MX' for Mexican Spanish or 'es-ES' for Spain Spanish
-            translation_path: Path to translation files directory
+            translation_path: Path to the distributed translation files directory
+            local_translation_path: Path to the operator's own translation files, merged
+                      over the distributed ones key by key. Defaults to
+                      ``<local_dir_path>/translations`` when set from config.
         """
         self.language = language
         self.translation_path = translation_path
@@ -89,52 +92,29 @@ class Translator:
             return fallback.copy()
 
         result = fallback.copy()
-
-        def merge_dict(target: dict, source: dict):
-            """Recursively merge source into target"""
-            for key, value in source.items():
-                if key in target and isinstance(target[key], dict) and isinstance(value, dict):
-                    merge_dict(target[key], value)
-                else:
-                    target[key] = value
-
-        merge_dict(result, primary)
-        return result
-
-    def _deep_merge_translations(self, primary: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
-        """
-        Perform a deep merge of translations with overrides taking precedence
-
-        Args:
-            primary: Primary translation dictionary (may be empty)
-            override: Translation dictionary to apply to Primary and override
-                      just values, not sub-dictionaries
-
-        Returns:
-            Merged dictionary with primary values overridden by override dictionary
-        """
-        # Start with a copy of the first dictionary to avoid side effects
-        result = primary.copy()
-
-        for key, value in override.items():
-            # If both values are dictionaries, merge them recursively
-            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-                result[key] = self._deep_merge_translations(result[key], value)
+        for key, value in primary.items():
+            existing = result.get(key)
+            if isinstance(existing, dict) and isinstance(value, dict):
+                # Rebuild the sub-dict rather than mutating it in place: it is still
+                # shared with `fallback`, which the caller keeps using.
+                result[key] = self._merge_translations(value, existing)
             else:
-                # Otherwise, overwrite the value or add the new key
                 result[key] = value
-
         return result
 
     def _load_file(self, lang: str) -> dict[str, Any]:
         """
-        Load translation files from distribution then local
+        Load a language's catalog: the distributed file, overlaid with the local one
+
+        The local catalog is merged key by key over the distributed one, so an operator
+        can translate their own local commands, or override individual strings, without
+        editing a shipped file.
 
         Args:
             lang: Language code
 
         Returns:
-            Dictionary of translations, empty dict if file not found
+            Dictionary of translations, empty dict if no catalog was found
         """
         file_path = Path(self.translation_path) / f"{lang}.json"
         local_file_path = Path(self.local_translation_path) / f"{lang}.json"
@@ -142,15 +122,20 @@ class Translator:
             # An explicitly configured filesystem catalog always wins.  The
             # package fallback makes the defaults work from an installed wheel
             # (where ``translations/`` is not relative to the current cwd).
-            xlate_table: dict[str, str] = {}
-            for xlate_file in (file_path, local_file_path):
-                if xlate_file.is_file():
-                    logger.info(f"Loading translation file: {xlate_file}")
-                    with open(xlate_file, encoding='utf-8') as f:
-                        xlate_table = self._deep_merge_translations(xlate_table, json.load(f))
-            if xlate_table:
-                # if xlate_table has been built, return it
-                return xlate_table
+            catalog: dict[str, Any] = {}
+            found = False
+            for path in (file_path, local_file_path):
+                if not path.is_file():
+                    continue
+                logger.info("Loading translation catalog: %s", path)
+                with open(path, encoding='utf-8') as f:
+                    # Later file wins on overlapping keys.
+                    catalog = self._merge_translations(json.load(f), catalog)
+                found = True
+            if found:
+                # A configured catalog wins even when it is empty, so an operator can
+                # deliberately blank one out without the bundled defaults reappearing.
+                return catalog
 
             if not self._uses_bundled_defaults():
                 return {}
@@ -159,10 +144,10 @@ class Translator:
                 return {}
             return json.loads(bundled.read_text(encoding="utf-8"))
         except json.JSONDecodeError as e:
-            print(f"Error parsing translation file {file_path}: {e}")
+            logger.error("Error parsing translation file for %r: %s", lang, e)
             return {}
         except Exception as e:
-            print(f"Error loading translation file {file_path}: {e}")
+            logger.error("Error loading translation file for %r: %s", lang, e)
             return {}
 
     def translate(self, key: str, **kwargs) -> str:

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -301,3 +301,88 @@ class TestReloadConfigMerge:
 
         assert observed
         assert observed <= {("old", "old", "old"), ("new", "new", "new")}
+
+
+class TestLocalTranslationPath:
+    """The local translation catalog follows [Bot] local_dir_path."""
+
+    def _bot_with_local_dir(self, tmp_path, local_dir_path: str | None):
+        db_path = tmp_path / "bot.db"
+        main_config = tmp_path / "config.ini"
+        text = _minimal_main_config(tmp_path, db_path)
+        if local_dir_path is not None:
+            text = text.replace("[Bot]\n", f"[Bot]\nlocal_dir_path = {local_dir_path}\n")
+        main_config.write_text(text, encoding="utf-8")
+        return MeshCoreBot(config_file=str(main_config))
+
+    def test_defaults_into_local_dir_path(self, tmp_path):
+        elsewhere = tmp_path / "somewhere-else"
+        elsewhere.mkdir()
+        bot = self._bot_with_local_dir(tmp_path, str(elsewhere))
+        assert bot.local_translation_path == str(elsewhere / "translations")
+
+    def test_defaults_to_local_when_unset(self, tmp_path):
+        bot = self._bot_with_local_dir(tmp_path, None)
+        # Absolute and anchored on the config's directory, not the process cwd.
+        assert bot.local_translation_path == str(tmp_path / "local" / "translations")
+
+    def test_explicit_setting_overrides_the_default(self, tmp_path):
+        custom = tmp_path / "my-catalogs"
+        custom.mkdir()
+        db_path = tmp_path / "bot.db"
+        main_config = tmp_path / "config.ini"
+        main_config.write_text(
+            _minimal_main_config(tmp_path, db_path)
+            + f"\n[Localization]\nlanguage = en\nlocal_translation_path = {custom.as_posix()}\n",
+            encoding="utf-8",
+        )
+        bot = MeshCoreBot(config_file=str(main_config))
+        assert bot.local_translation_path == str(custom)
+
+    def test_local_catalog_reaches_the_translator(self, tmp_path):
+        """End to end: a catalog under local_dir_path overrides a shipped string."""
+        import json
+
+        dist = tmp_path / "translations"
+        dist.mkdir()
+        (dist / "en.json").write_text(
+            json.dumps({"commands": {"ping": "shipped", "other": "keep"}}), encoding="utf-8"
+        )
+        local_translations = tmp_path / "local" / "translations"
+        local_translations.mkdir(parents=True)
+        (local_translations / "en.json").write_text(
+            json.dumps({"commands": {"ping": "from local"}}), encoding="utf-8"
+        )
+        db_path = tmp_path / "bot.db"
+        main_config = tmp_path / "config.ini"
+        main_config.write_text(
+            _minimal_main_config(tmp_path, db_path)
+            + f"\n[Localization]\nlanguage = en\ntranslation_path = {dist.as_posix()}\n",
+            encoding="utf-8",
+        )
+        bot = MeshCoreBot(config_file=str(main_config))
+        assert bot.translator.translate("commands.ping") == "from local"
+        assert bot.translator.translate("commands.other") == "keep"
+
+    def test_reload_picks_up_a_changed_local_translation_path(self, tmp_path):
+        """A reload must republish the local path, not keep the pre-reload one."""
+        db_path = tmp_path / "bot.db"
+        main_config = tmp_path / "config.ini"
+        main_config.write_text(
+            _minimal_main_config(tmp_path, db_path)
+            + "\n[Localization]\nlanguage = en\n",
+            encoding="utf-8",
+        )
+        bot = MeshCoreBot(config_file=str(main_config))
+        assert bot.local_translation_path == str(tmp_path / "local" / "translations")
+
+        moved = tmp_path / "moved-catalogs"
+        moved.mkdir()
+        main_config.write_text(
+            _minimal_main_config(tmp_path, db_path)
+            + f"\n[Localization]\nlanguage = en\nlocal_translation_path = {moved.as_posix()}\n",
+            encoding="utf-8",
+        )
+        success, _ = bot.reload_config()
+        assert success is True
+        assert bot.local_translation_path == str(moved)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,7 +256,8 @@ class TestResponseTranslators:
         b = object.__new__(MeshCoreBot)
         b.logger = MagicMock()
         b.translation_path = str(translations)
-        b.translator = Translator("en", b.translation_path)
+        b.local_translation_path = str(tmp_path / "local" / "translations")
+        b.translator = Translator("en", b.translation_path, b.local_translation_path)
         b._translator_cache = {"en": b.translator}
 
         assert b.available_languages() == {"en", "fr"}

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -204,3 +204,51 @@ class TestTranslatorWithRealFiles:
         t = Translator(language="xx", translation_path=str(tmp_path))
         result = t.get_value("grp.val")
         assert result == "found"
+
+
+class TestLocalCatalogOverlay:
+    """The local catalog overlays the distributed one, key by key."""
+
+    def _write(self, path, data):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_local_overrides_single_string(self, tmp_path):
+        dist, local = tmp_path / "dist", tmp_path / "local"
+        self._write(dist / "en.json", {"commands": {"a": "shipped", "b": "keep"}})
+        self._write(local / "en.json", {"commands": {"a": "overridden"}})
+        t = Translator("en", str(dist), str(local))
+        assert t.translate("commands.a") == "overridden"
+        # Sibling keys the local file does not mention survive.
+        assert t.translate("commands.b") == "keep"
+
+    def test_local_adds_keys_for_local_commands(self, tmp_path):
+        dist, local = tmp_path / "dist", tmp_path / "local"
+        self._write(dist / "en.json", {"commands": {"ping": "pong"}})
+        self._write(local / "en.json", {"commands": {"whois": "Looking up {call}"}})
+        t = Translator("en", str(dist), str(local))
+        assert t.translate("commands.whois", call="K7ABC") == "Looking up K7ABC"
+        assert t.translate("commands.ping") == "pong"
+
+    def test_local_only_catalog_is_used(self, tmp_path):
+        dist, local = tmp_path / "dist", tmp_path / "local"
+        dist.mkdir()
+        self._write(local / "en.json", {"commands": {"whois": "local only"}})
+        t = Translator("en", str(dist), str(local))
+        assert t.translate("commands.whois") == "local only"
+
+    def test_missing_local_dir_is_harmless(self, tmp_path):
+        dist = tmp_path / "dist"
+        self._write(dist / "en.json", {"commands": {"ping": "pong"}})
+        t = Translator("en", str(dist), str(tmp_path / "nope"))
+        assert t.translate("commands.ping") == "pong"
+
+    def test_merge_does_not_mutate_fallback(self):
+        """_merge_translations must not write through into its fallback's sub-dicts."""
+        t = Translator.__new__(Translator)
+        fallback = {"grp": {"x": "orig", "y": "keep"}}
+        result = t._merge_translations({"grp": {"x": "new"}}, fallback)
+        assert result["grp"]["x"] == "new"
+        # The caller's catalog is left exactly as it was.
+        assert fallback == {"grp": {"x": "orig", "y": "keep"}}
+        assert result["grp"] is not fallback["grp"]


### PR DESCRIPTION
## What this changes

Add the `local_translation_path` to the `Localization` section  of the configuration file to allow one to specify a local translation file outside the distributed translation files.

## Why

This allows translation files to be built for local commands without the need of altering the distributed ones.

## Testing

Currently in use on my meshcore-bot instance.

## Checklist

- [x] Branched from `dev` and targeting `dev`
- [ ] `make test` passes
- [x] `make lint` passes (ruff + mypy)
- [ ] ~Frontend lint passes if templates changed (`npm run lint:frontend`)~
- [ ] Tests added or updated for behavior changes
- [x] `CHANGELOG.md` updated under `## [Unreleased]` if user-visible
- [x] Config changes are reflected in `config.ini.example` (and the minimal/quickstart
      templates where relevant) — CI validates these with `validate_config.py --strict`
- [ ] ~New docs pages are added to `nav:` in `mkdocs.yml`~
- [ ] ~Any new command justifies its airtime and defaults conservatively~
